### PR TITLE
Fix safe import for matplotlib ticker

### DIFF
--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -53,6 +53,8 @@ def extend_safe_import_for_studio(safe_mock_modules_dict):
     additional = {
         "matplotlib": MagicMock(name="SafeMock_matplotlib"),
         "matplotlib.pyplot": MagicMock(name="SafeMock_matplotlib_pyplot"),
+        "matplotlib.font_manager": MagicMock(name="SafeMock_matplotlib_font_manager"),
+        "matplotlib.ticker": MagicMock(name="SafeMock_matplotlib_ticker"),
         "scipy": MagicMock(name="SafeMock_scipy"),
         "yaml": MagicMock(name="SafeMock_yaml"),
     }


### PR DESCRIPTION
## Summary
- extend the safe import function to mock `matplotlib.ticker`

## Testing
- `python -m pip install pytest` *(fails: No matching distribution found)*
- `python -m pytest -q` *(fails: No module named pytest)*