### PR TITLE
Fix safe import mocking for matplotlib ticker

### DIFF
--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -53,6 +53,8 @@ def extend_safe_import_for_studio(safe_mock_modules_dict):
     additional = {
         "matplotlib": MagicMock(name="SafeMock_matplotlib"),
         "matplotlib.pyplot": MagicMock(name="SafeMock_matplotlib_pyplot"),
+        "matplotlib.font_manager": MagicMock(name="SafeMock_matplotlib_font_manager"),
+        "matplotlib.ticker": MagicMock(name="SafeMock_matplotlib_ticker"),
         "scipy": MagicMock(name="SafeMock_scipy"),
         "yaml": MagicMock(name="SafeMock_yaml"),
     }


### PR DESCRIPTION
## Summary
- ensure `extend_safe_import_for_studio` also mocks `matplotlib.ticker`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python -m pytest -q` *(fails: No module named pytest)*