### PR TITLE
Add matplotlib ticker mock to extend safe import

### DIFF
--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -53,6 +53,8 @@ def extend_safe_import_for_studio(safe_mock_modules_dict):
     additional = {
         "matplotlib": MagicMock(name="SafeMock_matplotlib"),
         "matplotlib.pyplot": MagicMock(name="SafeMock_matplotlib_pyplot"),
+        "matplotlib.font_manager": MagicMock(name="SafeMock_matplotlib_font_manager"),
+        "matplotlib.ticker": MagicMock(name="SafeMock_matplotlib_ticker"),
         "scipy": MagicMock(name="SafeMock_scipy"),
         "yaml": MagicMock(name="SafeMock_yaml"),
     }


### PR DESCRIPTION
## Summary
- include `matplotlib.ticker` in `extend_safe_import_for_studio`

## Testing
- `python -m pip install -r requirements.txt` *(fails: No matching distribution found for pandas)*
- `python -m pytest -q` *(fails: No module named pytest)*