### PR TITLE
Ensure dummy libraries expose version info

### DIFF
--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -75,6 +75,7 @@ class DataLoadError(GoldAIError):
 
 # --- Dummy Library Classes for Fallbacks ---
 class DummyPandas:
+    __version__ = "0.0"
     DataFrame = type('DummyDataFrame', (object,), {})
     Series = type('DummySeries', (object,), {})
     Timestamp = type('DummyTimestamp', (object,), {})
@@ -117,6 +118,7 @@ class DummyPandas:
 
 
 class DummyNumpy:
+    __version__ = "0.0"
     nan = float('nan')
     inf = float('inf')
     integer = int


### PR DESCRIPTION
## Summary
- add `__version__` attributes to DummyPandas and DummyNumpy classes

## Testing
- `python -m py_compile gold_ai2025.py`
- `python -m pytest -q` *(fails: No module named pytest)*
- `python -m unittest test_gold_ai.py` *(fails: ModuleNotFoundError: No module named 'pytest')*