### PR TITLE
Patch AISTUDIO v4.9.26

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Agent: gold_ai_test_runner
-version: 4.9.25
+version: 4.9.26
 description: >
   This agent is responsible for validating the Gold AI backtesting and simulation system,
   focusing on robust import handling, mock patching of critical libraries, and unit test execution.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ pip install -r requirements.txt
 ## Running Tests
 
 ```bash
-pytest
-
-# View coverage information
-pytest --cov=gold_ai2025 --cov-report=term-missing
+# Run full test suite with coverage
+pytest -v --cov=gold_ai2025 --cov-report=term-missing
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- bump agent version to v4.9.26
- document pytest coverage command
- avoid calling `coverage.start()` automatically
- add edge case tests for fallback modules, prepare_datetime, fonts, and install success without version

## Testing
- `python -m unittest test_gold_ai.py -v`