### PR TITLE
Fix indentation error in test suite

### DIFF
--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -998,9 +998,11 @@ class TestWFVandLotSizingFix(unittest.TestCase):
             "MACD_hist_smooth": [0.1, 0.1],
             "RSI": [50, 50],
         })
-        df.index = self.ga.pd.to_datetime(["2023-01-01 00:00:00", "2023-01-01 00:01:00"])
-
-
+        df.index = self.ga.pd.to_datetime([
+            "2023-01-01 00:00:00",
+            "2023-01-01 00:01:00",
+        ])
+        cfg = self.ga.StrategyConfig({
             "use_reentry": True,
             "reentry_cooldown_bars": 0,
             "reentry_cooldown_after_tp_minutes": 0,


### PR DESCRIPTION
## Summary
- fix stray indent in `test_simulate_trades_multi_order_with_reentry_fixed`

## Testing
- `python3 test_gold_ai.py`