### PR TITLE
Fix BE-SL evaluation order

### DIFF
--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -6676,15 +6676,7 @@ def simulate_trades(df: pd.DataFrame, config: 'StrategyConfig') -> Tuple[list, l
             sl = order["stop_loss"]
             be_sl_thresh = getattr(config, "base_be_sl_r_threshold", 1.0)
             enable_be_sl = getattr(config, "enable_be_sl", True)
-            if row["High"] >= tp:
-                order["exit_price"] = tp
-                order["exit_reason"] = "TP"
-                order["exit_idx"] = bar_i
-                order["exit_time"] = current_time
-                order["pnl_usd_net"] = tp - entry_price if order.get("side", "BUY") == "BUY" else entry_price - tp
-                trade_log.append(order.copy())
-                active_orders.remove(order)
-                continue
+
             if enable_be_sl and ((row["High"] - entry_price) >= (tp - entry_price) * be_sl_thresh):
                 if row["Low"] <= entry_price:
                     order["exit_price"] = entry_price
@@ -6694,8 +6686,19 @@ def simulate_trades(df: pd.DataFrame, config: 'StrategyConfig') -> Tuple[list, l
                     order["pnl_usd_net"] = 0.0
                     trade_log.append(order.copy())
                     active_orders.remove(order)
-                    sim_logger.debug("[Patch AI Studio v4.9.26] Triggered BE-SL: %s", order)
+                    sim_logger.debug("[Patch AI Studio v4.9.27] Triggered BE-SL: %s", order)
                     continue
+
+            if row["High"] >= tp:
+                order["exit_price"] = tp
+                order["exit_reason"] = "TP"
+                order["exit_idx"] = bar_i
+                order["exit_time"] = current_time
+                order["pnl_usd_net"] = tp - entry_price if order.get("side", "BUY") == "BUY" else entry_price - tp
+                trade_log.append(order.copy())
+                active_orders.remove(order)
+                continue
+
             if row["Low"] <= sl:
                 order["exit_price"] = sl
                 order["exit_reason"] = "SL"


### PR DESCRIPTION
## Summary
- adjust `simulate_trades` to check BE-SL before TP/SL
- log BE-SL triggers with new patch id

## Testing
- `python -m unittest -v`