### PR TITLE
Implement robust type guard checks

### DIFF
--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -1695,6 +1695,7 @@ import ta  # Assumes 'ta' is imported and available (checked in Part 1)
 from sklearn.cluster import KMeans  # For context column calculation
 from sklearn.preprocessing import StandardScaler  # For context column calculation
 import gc  # For memory management
+import inspect
 
 # --- Feature Engineering Constants are NOW REMOVED FROM HERE ---
 # They are accessed via the `config: StrategyConfig` object passed to relevant functions.
@@ -1949,8 +1950,10 @@ def tag_price_structure_patterns(df: pd.DataFrame | Any, config: 'StrategyConfig
     """Tags price structure patterns based on various indicators, using config."""
     pattern_logger = logging.getLogger(f"{__name__}.tag_price_structure_patterns")
     pattern_logger.info("   (Processing) Tagging price structure patterns (using StrategyConfig)...")
-    if not isinstance(expected_type, (type, tuple)):
-        raise TypeError("expected_type must be a type or tuple")
+    # [Patch AI Studio v4.9.x] Robust type guard for expected_type
+    if not (isinstance(expected_type, (type, tuple)) and all(isinstance(t, type) for t in (expected_type if isinstance(expected_type, tuple) else [expected_type]))):
+        pattern_logger.error("[Patch] expected_type argument for isinstance is not a type or tuple of types. Got: %r", expected_type)
+        raise TypeError("[Patch] expected_type must be a type or tuple of types")
     if not isinstance(df, expected_type):
         pattern_logger.error("Input must be a pandas DataFrame.")
         return pd.DataFrame()
@@ -2029,8 +2032,10 @@ def calculate_m15_trend_zone(df_m15: pd.DataFrame | Any, config: 'StrategyConfig
     """Calculates M15 Trend Zone (UP, DOWN, NEUTRAL) using config."""
     m15_trend_logger = logging.getLogger(f"{__name__}.calculate_m15_trend_zone")
     m15_trend_logger.info("(Processing) กำลังคำนวณ M15 Trend Zone (using StrategyConfig)...")
-    if not isinstance(expected_type, (type, tuple)):
-        raise TypeError("expected_type must be a type or tuple")
+    # [Patch AI Studio v4.9.x] Robust type guard for expected_type
+    if not (isinstance(expected_type, (type, tuple)) and all(isinstance(t, type) for t in (expected_type if isinstance(expected_type, tuple) else [expected_type]))):
+        m15_trend_logger.error("[Patch] expected_type argument for isinstance is not a type or tuple of types. Got: %r", expected_type)
+        raise TypeError("[Patch] expected_type must be a type or tuple of types")
     if not isinstance(df_m15, expected_type):
         m15_trend_logger.error("Input must be a pandas DataFrame.")
         return pd.DataFrame()

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1508,10 +1508,26 @@ class TestBranchAndErrorPathCoverage:
         with pytest.raises(TypeError):
             ga.tag_price_structure_patterns([], ga.StrategyConfig({}), expected_type=123)
 
+    def test_tag_price_structure_patterns_expected_type_guard(self):
+        ga = safe_import_gold_ai()
+        cfg = ga.StrategyConfig({})
+        df = ga.pd.DataFrame()
+        with pytest.raises(TypeError):
+            ga.tag_price_structure_patterns(df, cfg, expected_type="notatype")
+        with pytest.raises(TypeError):
+            ga.tag_price_structure_patterns(df, cfg, expected_type=(str, "badtype"))
+
     def test_calculate_m15_trend_zone_empty_guard(self):
         ga = safe_import_gold_ai()
         with pytest.raises(TypeError):
             ga.calculate_m15_trend_zone({}, ga.StrategyConfig({}), expected_type=None)
+
+    def test_calculate_m15_trend_zone_expected_type_guard(self):
+        ga = safe_import_gold_ai()
+        cfg = ga.StrategyConfig({})
+        df = ga.pd.DataFrame()
+        with pytest.raises(TypeError):
+            ga.calculate_m15_trend_zone(df, cfg, expected_type=[])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce type guard validation in tag_price_structure_patterns
- enforce type guard validation in calculate_m15_trend_zone
- add tests for invalid expected_type

## Testing
- `python test_gold_ai.py`