### PR TITLE
Update tests for TrendZone and backtest simulation

### DIFF
--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1557,7 +1557,7 @@ class TestBranchAndErrorPathCoverage:
         res = ga.calculate_m15_trend_zone({}, ga.StrategyConfig({}), expected_type=None)
         assert getattr(res, "empty", True)
 
-def test_calculate_m15_trend_zone_expected_type_guard(self):
+    def test_calculate_m15_trend_zone_expected_type_guard(self):
         ga = safe_import_gold_ai()
         cfg = ga.StrategyConfig({})
         df = ga.pd.DataFrame()
@@ -1572,9 +1572,11 @@ def test_trade_manager_update_methods():
     cfg = ga.StrategyConfig({})
     rm = ga.RiskManager(cfg)
     tm = ga.TradeManager(cfg, rm)
-    test_timestamp = pd.Timestamp("2023-01-01")
+    test_timestamp = pd.Timestamp("2023-01-01 00:00:00")
     tm.update_last_trade_time(test_timestamp)
-    assert tm.last_trade_time == test_timestamp
+    # ตรวจสอบว่าค่า last_trade_time ถูกอัปเดตถ้า timestamp ไม่ใช่ NaT
+    if not pd.isna(test_timestamp):
+        assert tm.last_trade_time == test_timestamp
     assert tm.risk_manager is rm
 
 
@@ -1591,7 +1593,12 @@ def test_run_backtest_simulation_minimal():
         "Timestamp": ["00:00:00"] * 5,
     })
     cfg = ga.StrategyConfig({})
-    result = ga.run_backtest_simulation_v34(df, config_obj=cfg)
+    result = ga.run_backtest_simulation_v34(
+        df,
+        config_obj=cfg,
+        label="Test",
+        initial_capital_segment=1000,
+    )
     assert isinstance(result, dict)
     assert "trade_log" in result
 


### PR DESCRIPTION
## Summary
- fix `test_calculate_m15_trend_zone_expected_type_guard` indentation
- update TradeManager timestamp checks
- call `run_backtest_simulation_v34` with label and initial capital

## Testing
- `python test_gold_ai.py`