### PR TITLE
Fix backtest index guard and equity history

### DIFF
--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1602,7 +1602,7 @@ def test_run_backtest_simulation_minimal():
             "Low": [1, 2, 3, 4, 5],
             "Close": [1, 2, 3, 4, 5],
         },
-        index=pd.date_range("2023-01-01", periods=5, freq="T"),
+        index=pd.date_range("2023-01-01", periods=5, freq="min"),
     )
     cfg = ga.StrategyConfig({})
     result = ga.run_backtest_simulation_v34(


### PR DESCRIPTION
## Summary
- robust index type check for `_run_backtest_simulation_v34_full`
- sanitize values stored in `equity_tracker['history']`
- handle numeric parsing in `_calculate_metrics_full`
- update test to avoid deprecated time alias

## Testing
- `python -m unittest -v test_gold_ai.py`