### PR TITLE
Fix pandas import for backtest functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [v4.9.42+] - 2025-05-21
 - Added global pandas import to ensure backtest simulations access `pd` without errors.
+- Added explicit pandas import guard inside `run_backtest_simulation_v34` and `_run_backtest_simulation_v34_full` to avoid `UnboundLocalError` in mocked environments.
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.


### PR DESCRIPTION
## Summary
- ensure global pandas import explains patch
- add pandas import guard in `_run_backtest_simulation_v34_full`
- add pandas import guard in `run_backtest_simulation_v34`
- document patch in CHANGELOG

## Testing
- `python test_gold_ai.py -v`