### PR TITLE
Fix backtest argument order

### DIFF
--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -6991,11 +6991,13 @@ def run_backtest_simulation_v34(
             "[Patch AI Studio v4.9.34+] config_obj must be StrategyConfig, got %r"
             % type(config_obj)
         )
+    side_arg = kwargs.pop("side", "BUY")
     return _run_backtest_simulation_v34_full(
         df_m1_segment_pd,
-        config_obj,
         label,
         initial_capital_segment,
+        side_arg,
+        config_obj,
         risk_manager_obj,
         trade_manager_obj,
         **kwargs,


### PR DESCRIPTION
## Summary
- fix ordering of args in `run_backtest_simulation_v34`
- ensure side defaults to `BUY`

## Testing
- `python test_gold_ai.py`