### PR TITLE
Fix backtest argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,9 @@
 - Added global pandas import to ensure backtest simulations access `pd` without errors.
 - Added explicit pandas import guard inside `run_backtest_simulation_v34` and `_run_backtest_simulation_v34_full` to avoid `UnboundLocalError` in mocked environments.
 
+## [v4.9.43+] - 2025-05-22
+- Fixed argument order in `run_backtest_simulation_v34` and ensured side is parsed from kwargs.
+- Guarded `equity_tracker['current_equity']` comparison with numeric check and improved history update imports.
+
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.


### PR DESCRIPTION
## Summary
- fix ordering of args in `run_backtest_simulation_v34`
- ensure side defaults to `BUY`
- guard numeric update of equity tracker
- document patch in CHANGELOG

## Testing
- `python test_gold_ai.py`