### PR TITLE
Update README for v4.9.44 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
+The latest patch `[Patch AI Studio v4.9.44+]` changes `run_backtest_simulation_v34` to return a dictionary by default for easier QA validation.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.


### PR DESCRIPTION
## Summary
- note that run_backtest_simulation_v34 returns a dict by default

## Testing
- `python test_gold_ai.py`