### PR TITLE
Initialize optional library flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.45+
+**Version:** v4.9.46+
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  
 **Last updated:** 2025-05-23
@@ -12,7 +12,7 @@
 
 | Agent                  | Main Role           | Responsibilities                                                                                                                              |
 |------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.45+]` |
+| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.46+]` |
 | **Instruction_Bridge** | AI Studio Liaison  | Translates patch instructions to clear AI Studio/Codex prompts, organizes multi-step patching                                                 |
 | **Code_Runner_QA**     | Execution Test     | Runs scripts, collects pytest results, sets sys.path, checks logs, prepares zip for Studio/QA                                                 |
 | **GoldSurvivor_RnD**   | Strategy Analyst   | Analyzes TP1/TP2, SL, spike, pattern, verifies entry/exit correctness                                                                         |
@@ -55,10 +55,10 @@
 ## 🔁 Patch Protocols & Version Control
 
 - **Explicit Versioning:**  
-  All patches/agent changes must log version (e.g., `v4.9.45+`) matching latest codebase.
+  All patches/agent changes must log version (e.g., `v4.9.46+`) matching latest codebase.
 
 - **Patch Logging:**  
-  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, etc.
+  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.46+]`, etc.
   Any core logic change: notify relevant owners (GPT Dev, OMS_Guardian, ML_Innovator).
 
 - **Critical Constraints:**  
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.45+
+**Version:** 4.9.46+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -87,6 +87,7 @@
 - `[Patch AI Studio v4.9.42+]`: **Global import patch/fix for pandas (pd) across all simulation and backtest functions (prevents UnboundLocalError in minimal/edge/CI runs)**
 - `[Patch AI Studio v4.9.43+]`: **run_backtest_simulation_v34 always returns dict for QA, CI, minimal/mocked tests and all production runner calls.**
 - `[Patch AI Studio v4.9.45+]`: **Import error fixes, deferred GPU setup, and logging improvements for smoother CI/CD.**
+- `[Patch AI Studio v4.9.46+]`: **Initialize optional ML library flags to prevent UnboundLocalError across all modules.**
 - No dependencies beyond (`gold_ai2025.py`, `test_gold_ai.py`)
 
 ### 🧪 Mock Targets (for test_runner)
@@ -147,7 +148,7 @@ def _isinstance_safe(obj, expected_type):
     logging.error("[Patch AI Studio v4.9.40] _isinstance_safe: expected_type is not a valid type: %r, returning False.", expected_type)
     return False
 
-Release Note v4.9.45+ (Import Error Fix & QA Improvements)
+Release Note v4.9.46+ (Library Flags Initialization & QA Improvements)
 All core logic, simulation, ML, WFV, risk/trade, file export/reload, and E2E/integration paths must be covered in test_gold_ai.py and verified by Execution_Test_Unit.
 
 New integration/E2E scenarios must use the @pytest.mark.integration marker, random DataFrame fixtures, and full pipeline validation (from load_data → feature engineering → simulate_trades → export/reload).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,9 @@
 - Enhanced logging for library installation and Colab detection.
 - Updated version constants and documentation references.
 
+## [v4.9.46+] - 2025-05-23
+- Initialized all optional ML library flags inside `import_core_libraries` to avoid `UnboundLocalError` across inference and backtest modules.
+- Updated documentation and version constants.
+
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.45+]` changes `run_backtest_simulation_v34` to return a dictionary by default and improves import handling for enterprise CI.
+The latest patch `[Patch AI Studio v4.9.46+]` initializes all optional ML library flags to avoid `UnboundLocalError` during imports and maintains the default dictionary return for `run_backtest_simulation_v34`.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -1,7 +1,7 @@
 
 """
 Gold AI Enterprise v4.9.x
-[Patch AI Studio v4.9.45] - [Import Fix + Return Dict Default]: `run_backtest_simulation_v34` now returns a dictionary by default with optional legacy tuple and improved import handling.
+[Patch AI Studio v4.9.46] - [Import Flags Initialization]: initialize optional ML library flags to prevent UnboundLocalError across all modules.
 """
 
 # ==============================================================================
@@ -32,7 +32,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.45_RETURN_DICT"  # Updated version
+MINIMAL_SCRIPT_VERSION = "4.9.46_RETURN_DICT"  # Updated version
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -376,6 +376,24 @@ def import_core_libraries() -> None:
     global pd, np, tqdm, ta, optuna
     global CatBoostClassifier, Pool, EShapCalcType, EFeaturesSelectionAlgorithm
     global shap, GPUtil, psutil, torch
+    global catboost_module, optuna_module, ta_module, shap_module, tqdm_module
+
+    # [Patch AI Studio v4.9.46+] Initialize flags/modules to avoid UnboundLocalError
+    catboost_imported = False
+    optuna_imported = False
+    ta_imported = False
+    shap_imported = False
+    tqdm_imported = False
+    gputil_imported = False
+    psutil_imported = False
+    torch_imported = False
+    pandas_imported = False
+    numpy_imported = False
+    catboost_module = None
+    optuna_module = None
+    ta_module = None
+    shap_module = None
+    tqdm_module = None
 
     logger.info("\n(Processing) Importing core libraries (with robust fallbacks)...")
     warnings.filterwarnings("ignore", category=UserWarning, module='sklearn')
@@ -6964,7 +6982,7 @@ def run_backtest_simulation_v34(
 ) -> Any:
     """Run backtest simulation with explicit argument contract.
 
-    [Patch AI Studio v4.9.45+] Returns a dict by default for QA/production compatibility and fixes optional import edge cases.
+    [Patch AI Studio v4.9.46+] Returns a dict by default for QA/production compatibility and fixes optional import edge cases.
     Set ``return_tuple=True`` for legacy tuple output.
     """
     # [Patch AI Studio v4.9.42+] Robust pd import for test/CI edge case

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1,6 +1,6 @@
 """Gold AI Test Suite
 
-[Patch AI Studio v4.9.45] - Validate global pandas availability, import fixes, and new return structure.
+[Patch AI Studio v4.9.46] - Validate global pandas availability, import fixes, and new return structure.
 """
 
 import importlib


### PR DESCRIPTION
## Summary
- avoid unbound local errors by initializing optional library flags and modules
- bump version references to v4.9.46
- document change in CHANGELOG and README
- update AGENTS instructions for new version
- adjust test suite header

## Testing
- `pytest -v --cov=gold_ai2025.py --cov=test_gold_ai.py` *(fails: command not found)*