### PR TITLE
Patch AI Studio v4.9.48+ optuna.logging mock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.47+
+**Version:** v4.9.48+
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  
 **Last updated:** 2025-05-23
@@ -12,7 +12,7 @@
 
 | Agent                  | Main Role           | Responsibilities                                                                                                                              |
 |------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.47+]` |
+| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.48+]` |
 | **Instruction_Bridge** | AI Studio Liaison  | Translates patch instructions to clear AI Studio/Codex prompts, organizes multi-step patching                                                 |
 | **Code_Runner_QA**     | Execution Test     | Runs scripts, collects pytest results, sets sys.path, checks logs, prepares zip for Studio/QA                                                 |
 | **GoldSurvivor_RnD**   | Strategy Analyst   | Analyzes TP1/TP2, SL, spike, pattern, verifies entry/exit correctness                                                                         |
@@ -55,10 +55,10 @@
 ## 🔁 Patch Protocols & Version Control
 
 - **Explicit Versioning:**  
-  All patches/agent changes must log version (e.g., `v4.9.47+`) matching latest codebase.
+  All patches/agent changes must log version (e.g., `v4.9.48+`) matching latest codebase.
 
 - **Patch Logging:**  
-  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.47+]`, etc.
+  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.48+]`, etc.
   Any core logic change: notify relevant owners (GPT Dev, OMS_Guardian, ML_Innovator).
 
 - **Critical Constraints:**  
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.47+
+**Version:** 4.9.48+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -89,6 +89,7 @@
 - `[Patch AI Studio v4.9.45+]`: **Import error fixes, deferred GPU setup, and logging improvements for smoother CI/CD.**
 - `[Patch AI Studio v4.9.46+]`: **Initialize optional ML library flags to prevent UnboundLocalError across all modules.**
 - `[Patch AI Studio v4.9.47+]`: **Mock missing ML/TA libs for CI/CD tests**
+- `[Patch AI Studio v4.9.48+]`: **Add optuna.logging mock for CI/CD compatibility**
 - No dependencies beyond (`gold_ai2025.py`, `test_gold_ai.py`)
 
 ### 🧪 Mock Targets (for test_runner)
@@ -160,6 +161,9 @@ All patches must include log marker and notification for version, agent, and aff
 Release Note v4.9.47+ (Mock ML/TA libs for CI/CD)
 - Added sys.modules mocks for `ta`, `optuna`, and `catboost` in test_gold_ai.py to prevent ImportError during automation.
 - Production logic unchanged; ensures pytest passes in minimal environments.
+Release Note v4.9.48+ (Optuna logging mock)
+- Added optuna.logging module to mocked optuna to ensure verbosity setup works.
+
 
 ✅ QA Flow & Testing Requirements (v4.9.43+)
 Coverage Target:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Mocked missing ML/TA libraries (`ta`, `optuna`, `catboost`) in `test_gold_ai.py` to ensure CI/CD environments without these packages pass all tests.
 - Documentation and version constants updated.
 
+## [v4.9.48+] - 2025-05-23
+- Added mock submodule `optuna.logging` in `test_gold_ai.py` to prevent `AttributeError` when `optuna` is missing.
+- Updated version constants and documentation references.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.47+]` mocks TA-related libraries in the test suite so CI/CD passes even without `ta`, `optuna`, or `catboost` installed.
+The latest patch `[Patch AI Studio v4.9.48+]` mocks TA-related libraries in the test suite so CI/CD passes even without `ta`, `optuna`, or `catboost` installed.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -1,7 +1,7 @@
 
 """
 Gold AI Enterprise v4.9.x
-[Patch AI Studio v4.9.47] - [Import Flags Initialization]: initialize optional ML library flags to prevent UnboundLocalError across all modules.
+[Patch AI Studio v4.9.48] - [Import Flags Initialization]: initialize optional ML library flags to prevent UnboundLocalError across all modules.
 """
 
 # ==============================================================================
@@ -32,7 +32,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.47_RETURN_DICT"  # Updated version
+MINIMAL_SCRIPT_VERSION = "4.9.48_RETURN_DICT"  # Updated version
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -378,7 +378,7 @@ def import_core_libraries() -> None:
     global shap, GPUtil, psutil, torch
     global catboost_module, optuna_module, ta_module, shap_module, tqdm_module
 
-    # [Patch AI Studio v4.9.47+] Initialize flags/modules to avoid UnboundLocalError
+    # [Patch AI Studio v4.9.48+] Initialize flags/modules to avoid UnboundLocalError
     catboost_imported = False
     optuna_imported = False
     ta_imported = False
@@ -6982,7 +6982,7 @@ def run_backtest_simulation_v34(
 ) -> Any:
     """Run backtest simulation with explicit argument contract.
 
-    [Patch AI Studio v4.9.47+] Returns a dict by default for QA/production compatibility and fixes optional import edge cases.
+    [Patch AI Studio v4.9.48+] Returns a dict by default for QA/production compatibility and fixes optional import edge cases.
     Set ``return_tuple=True`` for legacy tuple output.
     """
     # [Patch AI Studio v4.9.42+] Robust pd import for test/CI edge case

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1,6 +1,6 @@
 """Gold AI Test Suite
 
-[Patch AI Studio v4.9.47] - Validate global pandas availability, import fixes, and new return structure.
+[Patch AI Studio v4.9.48] - Validate global pandas availability, import fixes, and new return structure.
 """
 
 import importlib
@@ -60,7 +60,7 @@ except Exception:  # pragma: no cover - coverage library not installed
     cov = None
 
 
-# === [Patch AI Studio v4.9.47] - Mock missing ML/TA libs for CI/CD ===
+# === [Patch AI Studio v4.9.48] - Mock missing ML/TA libs for CI/CD ===
 import sys
 import types
 
@@ -92,6 +92,15 @@ def _create_mock_module(name: str) -> types.ModuleType:
                         data[k.strip()] = val
             return data
         module.safe_load = safe_load  # type: ignore
+    if name == "optuna":
+        logging_mod = types.ModuleType("optuna.logging")
+        logging_mod.WARNING = 30
+        logging_mod.set_verbosity = MagicMock(name="optuna.logging.set_verbosity")
+        module.logging = logging_mod
+        sys.modules.setdefault("optuna.logging", logging_mod)
+    if name == "optuna.logging":
+        module.WARNING = 30
+        module.set_verbosity = MagicMock(name="optuna.logging.set_verbosity")
     return module
 
 
@@ -128,6 +137,7 @@ def safe_import_gold_ai(ipython_ret=None, drive_mod=None) -> types.ModuleType:
         "matplotlib.font_manager": _create_mock_module("matplotlib.font_manager"),
         "scipy": _create_mock_module("scipy"),
         "optuna": _create_mock_module("optuna"),
+        "optuna.logging": _create_mock_module("optuna.logging"),
         "GPUtil": _create_mock_module("GPUtil"),
         "psutil": _create_mock_module("psutil"),
         "cv2": _create_mock_module("cv2"),


### PR DESCRIPTION
## Summary
- update version references to v4.9.48+
- add optuna.logging module in test mocks
- bump minimal script version
- document changes in CHANGELOG and AGENTS

## Testing
- `python3 -m unittest -v test_gold_ai.py`