### PR TITLE
Fix datetime hotfix and improve WFV compat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.50+
+**Version:** v4.9.51+
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  
-**Last updated:** 2025-05-23
+**Last updated:** 2025-05-24
 
 ---
 
@@ -12,7 +12,7 @@
 
 | Agent                  | Main Role           | Responsibilities                                                                                                                              |
 |------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.50+]` |
+| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.51+]` |
 | **Instruction_Bridge** | AI Studio Liaison  | Translates patch instructions to clear AI Studio/Codex prompts, organizes multi-step patching                                                 |
 | **Code_Runner_QA**     | Execution Test     | Runs scripts, collects pytest results, sets sys.path, checks logs, prepares zip for Studio/QA                                                 |
 | **GoldSurvivor_RnD**   | Strategy Analyst   | Analyzes TP1/TP2, SL, spike, pattern, verifies entry/exit correctness                                                                         |
@@ -55,10 +55,10 @@
 ## 🔁 Patch Protocols & Version Control
 
 - **Explicit Versioning:**  
-  All patches/agent changes must log version (e.g., `v4.9.50+`) matching latest codebase.
+  All patches/agent changes must log version (e.g., `v4.9.51+`) matching latest codebase.
 
 - **Patch Logging:**  
-  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.49+]`, `[v4.9.50+]`, etc.
+  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.49+]`, `[v4.9.50+]`, `[v4.9.51+]`, etc.
   Any core logic change: notify relevant owners (GPT Dev, OMS_Guardian, ML_Innovator).
 
 - **Critical Constraints:**  
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.50+
+**Version:** 4.9.51+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -168,6 +168,11 @@ Release Note v4.9.48+ (Optuna logging mock)
 Release Note v4.9.50+ (ADA test API sync)
 - Added compatibility wrapper to safely call `optuna.logging.set_verbosity` or `optuna.set_verbosity`.
 - Logs every branch and warns if optuna is missing or mocked.
+
+Release Note v4.9.51+ (Legacy WFV compat & TA mock)
+- Hotfix for `prepare_datetime` year detection using `datetime.now()`.
+- `run_all_folds_with_threshold` now accepts legacy args and auto-dummy objects.
+- Test suite uses expanded TA mock with submodules.
 
 
 ✅ QA Flow & Testing Requirements (v4.9.43+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@
 - Added `_robust_kwargs_guard` helper to absorb unexpected kwargs.
 - Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.50_FULL_PASS`.
 
+## [v4.9.51+] - 2025-05-24
+- Hotfix `prepare_datetime` uses `datetime.now()` correctly.
+- `run_all_folds_with_threshold` now accepts legacy argument order and provides
+  dummy defaults for missing objects.
+- Enhanced test TA mock with trend/momentum/volatility submodules.
+- Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.51_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.50+]` adds ADA test API sync and robust Optuna logging compatibility so CI/CD passes even without `ta`, `optuna`, or `catboost` installed.
+The latest patch `[Patch AI Studio v4.9.51+]` adds legacy WFV compatibility, TA mock improvements, and a datetime hotfix.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -101,6 +101,38 @@ def _create_mock_module(name: str) -> types.ModuleType:
     if name == "optuna.logging":
         module.WARNING = 30
         module.set_verbosity = MagicMock(name="optuna.logging.set_verbosity")
+    if name == "ta":
+        trend = types.ModuleType("ta.trend")
+        momentum = types.ModuleType("ta.momentum")
+        volatility = types.ModuleType("ta.volatility")
+        class MACD:
+            def __init__(self, **kwargs):
+                pass
+            def macd(self):
+                return pd.Series([0]) if pd is not None else [0]
+            def macd_diff(self):
+                return pd.Series([0]) if pd is not None else [0]
+            def macd_signal(self):
+                return pd.Series([0]) if pd is not None else [0]
+        class RSIIndicator:
+            def __init__(self, **kwargs):
+                pass
+            def rsi(self):
+                return pd.Series([50]) if pd is not None else [50]
+        class ATR:
+            def __init__(self, **kwargs):
+                pass
+            def average_true_range(self):
+                return pd.Series([1.0]) if pd is not None else [1.0]
+        trend.MACD = MACD
+        momentum.RSIIndicator = RSIIndicator
+        volatility.ATR = ATR
+        module.trend = trend
+        module.momentum = momentum
+        module.volatility = volatility
+        sys.modules.setdefault("ta.trend", trend)
+        sys.modules.setdefault("ta.momentum", momentum)
+        sys.modules.setdefault("ta.volatility", volatility)
     return module
 
 


### PR DESCRIPTION
## Summary
- hotfix `prepare_datetime` to use `datetime.now`
- allow `run_all_folds_with_threshold` legacy argument order
- provide dummy defaults for missing manager objects
- extend TA mocking in tests for trend/momentum/volatility
- bump version references to v4.9.51

## Testing
- `python -m unittest discover -v`