### PR TITLE
Fix WFV result structure and numpy import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.52+
+**Version:** v4.9.53+
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  
 **Last updated:** 2025-05-25
@@ -12,7 +12,7 @@
 
 | Agent                  | Main Role           | Responsibilities                                                                                                                              |
 |------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.52+]` |
+| **GPT Dev**            | Core Algo Dev      | Implements/patches core logic (simulate_trades, update_trailing_sl, run_backtest_simulation_v34), SHAP/MetaModel, applies `[Patch AI Studio v4.9.26+]` – `[v4.9.53+]` |
 | **Instruction_Bridge** | AI Studio Liaison  | Translates patch instructions to clear AI Studio/Codex prompts, organizes multi-step patching                                                 |
 | **Code_Runner_QA**     | Execution Test     | Runs scripts, collects pytest results, sets sys.path, checks logs, prepares zip for Studio/QA                                                 |
 | **GoldSurvivor_RnD**   | Strategy Analyst   | Analyzes TP1/TP2, SL, spike, pattern, verifies entry/exit correctness                                                                         |
@@ -55,10 +55,10 @@
 ## 🔁 Patch Protocols & Version Control
 
 - **Explicit Versioning:**  
-  All patches/agent changes must log version (e.g., `v4.9.52+`) matching latest codebase.
+  All patches/agent changes must log version (e.g., `v4.9.53+`) matching latest codebase.
 
 - **Patch Logging:**  
-  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.49+]`, `[v4.9.50+]`, `[v4.9.51+]`, `[v4.9.52+]`, etc.
+  All logic changes must log `[Patch AI Studio v4.9.26+]`, `[v4.9.29+]`, `[v4.9.34+]`, `[v4.9.39+]`, `[v4.9.40+]`, `[v4.9.41+]`, `[v4.9.42+]`, `[v4.9.43+]`, `[v4.9.44+]`, `[v4.9.45+]`, `[v4.9.49+]`, `[v4.9.50+]`, `[v4.9.51+]`, `[v4.9.52+]`, `[v4.9.53+]`, etc.
   Any core logic change: notify relevant owners (GPT Dev, OMS_Guardian, ML_Innovator).
 
 - **Critical Constraints:**  
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.52+
+**Version:** 4.9.53+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -178,6 +178,10 @@ Release Note v4.9.52+ (Datetime & Index Guards)
 - Added `_ensure_datetimeindex` to softly convert/warn when index is not DatetimeIndex.
 - Added `_raise_or_warn` helper for test-friendly exceptions.
 - `simulate_trades` absorbs `side` kwarg without effect.
+
+Release Note v4.9.53+ (WFVResult Wrapper & np Safety)
+- Walk-forward orchestration now returns `WFVResult` for dict-style access while maintaining tuple compatibility.
+- Backtest simulation imports numpy locally to prevent `UnboundLocalError` under mocked imports.
 
 
 ✅ QA Flow & Testing Requirements (v4.9.43+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@
 - Updated tests to provide dummy RiskManager to `TradeManager`.
 - Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.52_FULL_PASS`.
 
+## [v4.9.53+] - 2025-05-26
+- `run_all_folds_with_threshold` returns `WFVResult` supporting dict-style access.
+- `_run_backtest_simulation_v34_full` now imports numpy locally to avoid `UnboundLocalError`.
+- Version bumped to `4.9.53_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.52+]` introduces test-aware datetime handling, DataFrame index guards, and simulate_trades side kwarg support.
+The latest patch `[Patch AI Studio v4.9.53+]` introduces improved result handling for walk-forward simulations and ensures numpy availability within backtest loops.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.


### PR DESCRIPTION
## Summary
- bump version to 4.9.53
- add `WFVResult` namedtuple for walk-forward orchestration
- ensure numpy is imported inside `_run_backtest_simulation_v34_full`
- update README and docs

## Testing
- `pytest -v --cov=gold_ai2025.py --cov=test_gold_ai.py` *(fails: No module named pytest)*