### PR TITLE
Fix simulate_trades return type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.54+
-**Project:** Gold AI (Enterprise Refactor)  
-**Maintainer:** AI Studio QA/Dev Team  
+**Version:** v4.9.55+
+**Project:** Gold AI (Enterprise Refactor)
+**Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-05-27
 
 ---
@@ -205,8 +205,9 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.43+]
-เพิ่ม Robust Numeric TypeGuard สำหรับ equity history ใน simulation/backtest
+ล่าสุด: [Patch AI Studio v4.9.55+]
+เพิ่ม default dict return ใน `simulate_trades` พร้อมตัวเลือก `return_tuple` 
+เพื่อรองรับ backward compatibility และ QA
 
 ตรวจสอบ audit log & error log ว่า non-numeric (str/NaT/None/nan) ถูก block และ log warning อย่างถูกต้อง
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@
 - `__getitem__` now delegates to `tuple.__getitem__` to avoid runtime errors.
 - Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.54_FULL_PASS`.
 
+## [v4.9.55+] - 2025-05-27
+- `simulate_trades` now returns a dictionary by default for QA compatibility.
+- Legacy tuple output remains available via `return_tuple=True`.
+- Unit tests updated to request tuple output when needed.
+- Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.55_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -33,7 +33,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.54_FULL_PASS"  # Updated version
+MINIMAL_SCRIPT_VERSION = "4.9.55_FULL_PASS"  # Updated version
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -6974,8 +6974,18 @@ part14_logger.debug("Part 14: Placeholder for Future Additions reached.")
 
 # --- Simplified Helper Functions for Unit Tests ---
 
-def simulate_trades(df: pd.DataFrame, config: 'StrategyConfig', *args, **kwargs) -> Tuple[list, list, dict]:
-    """Simplified trade simulator with basic multi-order and BE-SL logic."""
+def simulate_trades(
+    df: pd.DataFrame,
+    config: 'StrategyConfig',
+    *args,
+    return_tuple: bool = False,
+    **kwargs,
+) -> Any:
+    """Simplified trade simulator with basic multi-order and BE-SL logic.
+
+    [Patch AI Studio v4.9.54+] Returns a dict by default for easier QA
+    consumption while preserving backward compatibility via ``return_tuple``.
+    """
     # PATCH [v4.9.52+] Absorb side and unused kwargs for test compatibility
     side_override = kwargs.pop("side", None)
     if side_override is not None:
@@ -6989,7 +6999,14 @@ def simulate_trades(df: pd.DataFrame, config: 'StrategyConfig', *args, **kwargs)
     run_summary: dict = {}
 
     if df is None or df.empty:
-        return trade_log, equity_curve, run_summary
+        result_tuple = (trade_log, equity_curve, run_summary)
+        if return_tuple:
+            return result_tuple
+        return {
+            "trade_log": trade_log,
+            "equity_curve": equity_curve,
+            "run_summary": run_summary,
+        }
 
     equity = getattr(config, "initial_capital", 0.0)
     drawdown_peak = equity
@@ -7125,7 +7142,14 @@ def simulate_trades(df: pd.DataFrame, config: 'StrategyConfig', *args, **kwargs)
                 })
 
     run_summary["num_trades"] = len(trade_log)
-    return trade_log, equity_curve, run_summary
+    result_tuple = (trade_log, equity_curve, run_summary)
+    if return_tuple:
+        return result_tuple
+    return {
+        "trade_log": trade_log,
+        "equity_curve": equity_curve,
+        "run_summary": run_summary,
+    }
 
 def calculate_metrics(trade_log: list, fold_tag: str = "") -> Dict[str, Any]:
     """Calculate basic metrics for a list-based trade log."""

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -728,7 +728,7 @@ class TestEdgeCases(unittest.TestCase):
         })
         df.index = self.ga.pd.date_range("2023-01-01", periods=2, freq="min")
         cfg = self.ga.StrategyConfig({"risk_per_trade": 0.01})
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertIsInstance(trade_log, list)
         self.assertIsInstance(equity_curve, list)
         self.assertIsInstance(run_summary, dict)
@@ -753,7 +753,7 @@ class TestEdgeCases(unittest.TestCase):
         }, index=self.ga.pd.date_range("2023-01-01", periods=4, freq="min"))
 
         cfg = self.ga.StrategyConfig({"risk_per_trade": 0.01})
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
 
         self.assertGreaterEqual(len(trade_log), 1)
         self.assertIn(trade_log[0]["exit_reason"], {"TP", "SL", "BE-SL"})
@@ -783,7 +783,7 @@ class TestEdgeCases(unittest.TestCase):
             "trailing_sl_distance": 1.5,
         })
 
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertEqual(len(trade_log), 1)
         self.assertIn(trade_log[0]["exit_reason"], {"TSL", "TP", "BE-SL", "SL"})
 
@@ -954,7 +954,7 @@ class TestWFVandLotSizing(unittest.TestCase):
             "reentry_cooldown_after_tp_minutes": 0,
             "initial_capital": 100.0,
         })
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertGreaterEqual(len(trade_log), 2)
         self.assertIn(trade_log[0]["exit_reason"], {"TP", "TSL", "BE-SL", "SL"})
         self.assertIn(trade_log[1]["exit_reason"], {"TP", "TSL", "BE-SL", "SL"})
@@ -1083,7 +1083,7 @@ class TestTP2AndBESL(unittest.TestCase):
             "default_sl_multiplier": 1.0,
         })
         df = generate_df_tp2_besl(self.ga.pd)
-        trade_log, equity, summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity, summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertGreaterEqual(len(trade_log), 1)
         self.assertIn(
             trade_log[0]["exit_reason"], {"TP", "SL", "PartialTP", "BE-SL"}
@@ -1115,7 +1115,7 @@ class TestTP2AndBESL(unittest.TestCase):
             "MACD_hist_smooth": [0.1] * 7,
             "RSI": [50] * 7,
         }, index=self.ga.pd.date_range("2023-01-01", periods=7, freq="min"))
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         print("=== trade_log for BE-SL debug ===")
         for t in trade_log:
             print(t)
@@ -1151,7 +1151,7 @@ class TestTP2AndBESL(unittest.TestCase):
             "partial_tp_move_sl_to_entry": True,
         })
 
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertTrue(any(t["exit_reason"] in {"TSL", "TP", "BE-SL"} for t in trade_log))
 
     def test_simulate_trades_with_kill_switch_activation(self):
@@ -1183,7 +1183,7 @@ class TestTP2AndBESL(unittest.TestCase):
 
         run_summary = {}
         try:
-            trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+            trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         except RuntimeError:
             run_summary["hard_kill_triggered"] = True
 
@@ -1243,7 +1243,7 @@ class TestWFVandLotSizingFix(unittest.TestCase):
             "reentry_cooldown_after_tp_minutes": 0,
             "initial_capital": 100.0,
         })
-        trade_log, equity_curve, summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertEqual(len(trade_log), 2)
         # Accept TP or BE-SL as valid, since BE-SL can occur due to tight BE logic
         self.assertIn(trade_log[0]["exit_reason"], ["TP", "BE-SL"])
@@ -1278,7 +1278,7 @@ class TestWFVandLotSizingFix(unittest.TestCase):
             "risk_per_trade": 0.01,
         })
 
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertGreaterEqual(len(trade_log), 2)
         self.assertIn(trade_log[0]["exit_reason"], {"TP", "TSL", "BE-SL", "SL"})
         self.assertIn(trade_log[1]["exit_reason"], {"TP", "TSL", "BE-SL", "SL"})
@@ -1312,7 +1312,7 @@ class TestWFVandLotSizingFix(unittest.TestCase):
             "initial_capital": 100.0,
             "risk_per_trade": 0.01,
         })
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertGreaterEqual(len(trade_log), 2)
         exit_reasons = set(t['exit_reason'] for t in trade_log)
         self.assertTrue(all(reason in {"TP", "SL", "BE-SL", "TSL"} for reason in exit_reasons))
@@ -1346,7 +1346,7 @@ class TestWFVandLotSizingFix(unittest.TestCase):
             "initial_capital": 100.0,
             "risk_per_trade": 0.01,
         })
-        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg)
+        trade_log, equity_curve, run_summary = self.ga.simulate_trades(df.copy(), cfg, return_tuple=True)
         self.assertGreaterEqual(len(trade_log), 2)
         times = [t['entry_time'] for t in trade_log]
         self.assertEqual(len(times), len(set(times)))


### PR DESCRIPTION
## Summary
- update agent documentation and changelog for latest patch
- bump `MINIMAL_SCRIPT_VERSION`

## Testing
- `python -m pytest -v --cov=gold_ai2025.py --cov=test_gold_ai.py` *(fails: No module named pytest)*