### PR TITLE
Add ensure_dataframe and logging updates (v4.9.57)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.56+
+**Version:** v4.9.57+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-05-27
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.56+
+**Version:** 4.9.57+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@
 - Updated tests to request tuple output explicitly where required.
 - Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.56_FULL_PASS`.
 
+## [v4.9.57+] - 2025-05-27
+- Added `ensure_dataframe` utility for safe export of results.
+- Expanded logging in `RiskManager.update_drawdown` and `spike_guard_blocked`.
+- Updated tests to guard export serialization.
+- Bumped `MINIMAL_SCRIPT_VERSION` to `4.9.57_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.56+]` introduces contract logging in `simulate_trades` and adds kwargs guarding in `calculate_metrics`.
+The latest patch `[Patch AI Studio v4.9.57+]` adds `ensure_dataframe` for safe export and extends RiskManager/SpikeGuard logging.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.


### PR DESCRIPTION
## Summary
- add `ensure_dataframe` helper and document simulate_trades return
- improve RiskManager and spike_guard logging
- guard DataFrame export in tests
- bump minimal version and docs to v4.9.57
- update CHANGELOG

## Testing
- `python test_gold_ai.py`