### PR TITLE
Fix equity tracker history and trade log output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,8 +205,8 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.60+]
-เพิ่ม default dict return ใน `simulate_trades` พร้อมตัวเลือก `return_tuple` 
+ล่าสุด: [Patch AI Studio v4.9.62+]
+เพิ่ม default dict return ใน `simulate_trades` พร้อมตัวเลือก `return_tuple`
 เพื่อรองรับ backward compatibility และ QA
 
 ตรวจสอบ audit log & error log ว่า non-numeric (str/NaT/None/nan) ถูก block และ log warning อย่างถูกต้อง

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@
 - Updated tests to use datasets with valid entry signals.
 - Version bumped to `4.9.61_FULL_PASS`.
 
+## [v4.9.62+] - 2025-05-30
+- Equity tracker history now stored as dict keyed by timestamp for WFV merge.
+- `simulate_trades` always returns DataFrame trade log.
+- `run_all_folds_with_threshold` handles list-based histories for backward compatibility.
+- Bumped version constant to `4.9.62_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.


### PR DESCRIPTION
## Summary
- store equity history as timestamp-keyed dict
- ensure simulate_trades outputs a DataFrame trade log
- support list or dict equity histories when merging folds
- bump version to 4.9.62
- update changelog and agent instructions

## Testing
- `python3 -m py_compile gold_ai2025.py test_gold_ai.py`