### PR TITLE
Fix simulate_trades tuple return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@
 - `run_all_folds_with_threshold` handles list-based histories for backward compatibility.
 - Bumped version constant to `4.9.62_FULL_PASS`.
 
+## [v4.9.63+] - 2025-05-30
+- Fixed legacy tuple output of `simulate_trades` to return list-based trade log for
+  backward compatibility with unit tests.
+- Updated `MINIMAL_SCRIPT_VERSION` to `4.9.63_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -36,7 +36,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.62_FULL_PASS"  # [Patch AI Studio v4.9.62+] Spike guard & equity tracker fixes
+MINIMAL_SCRIPT_VERSION = "4.9.63_FULL_PASS"  # [Patch AI Studio v4.9.63+] Simulate trades tuple fix
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -7238,17 +7238,17 @@ def simulate_trades(
 
     run_summary["num_trades"] = len(trade_log)
     trade_log_df = pd.DataFrame(trade_log)
-    result_tuple = (trade_log_df, equity_curve, run_summary)
+    if return_tuple:
+        sim_logger.debug(
+            "[Patch AI Studio v4.9.63+] Returning tuple for legacy/test compatibility"
+        )
+        return (trade_log, equity_curve, run_summary)
+
     result_dict = {
         "trade_log": trade_log_df,
         "equity_curve": equity_curve,
         "run_summary": run_summary,
     }
-    if return_tuple:
-        sim_logger.debug(
-            "[Patch AI Studio v4.9.56+] Returning tuple for legacy/test compatibility"
-        )
-        return result_tuple
     sim_logger.debug("[Patch AI Studio v4.9.56+] Returning dict (default)")
     return result_dict
 


### PR DESCRIPTION
## Summary
- ensure `simulate_trades` returns list trade log when `return_tuple=True`
- bump script version to `4.9.63_FULL_PASS`
- document change in `CHANGELOG.md`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*