### PR TITLE
Fix empty trade_log DataFrame and bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.61+
+**Version:** v4.9.64+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-05-29
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.60+
+**Version:** 4.9.64+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -205,7 +205,7 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.62+]
+ล่าสุด: [Patch AI Studio v4.9.64+]
 เพิ่ม default dict return ใน `simulate_trades` พร้อมตัวเลือก `return_tuple`
 เพื่อรองรับ backward compatibility และ QA
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@
   backward compatibility with unit tests.
 - Updated `MINIMAL_SCRIPT_VERSION` to `4.9.63_FULL_PASS`.
 
+## [v4.9.64+] - 2025-05-31
+- `simulate_trades` initializes an empty DataFrame with `exit_reason` column when no trades occur.
+- Bumped version constant to `4.9.64_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.60+]` adds enhanced unit test assertions and export handling.
+The latest patch `[Patch AI Studio v4.9.64+]` adds trade_log column fixes for empty results.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -36,7 +36,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.63_FULL_PASS"  # [Patch AI Studio v4.9.63+] Simulate trades tuple fix
+MINIMAL_SCRIPT_VERSION = "4.9.64_FULL_PASS"  # [Patch AI Studio v4.9.64+] trade_log column fix
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -7238,6 +7238,11 @@ def simulate_trades(
 
     run_summary["num_trades"] = len(trade_log)
     trade_log_df = pd.DataFrame(trade_log)
+    if trade_log_df.empty:
+        trade_log_df = pd.DataFrame(columns=["exit_reason"])
+        sim_logger.debug(
+            "[Patch AI Studio v4.9.64+] Initialized empty trade_log_df with exit_reason column"
+        )
     if return_tuple:
         sim_logger.debug(
             "[Patch AI Studio v4.9.63+] Returning tuple for legacy/test compatibility"

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1,6 +1,6 @@
 """Gold AI Test Suite
 
-[Patch AI Studio v4.9.49] - Validate global pandas availability, import fixes, and new return structure.
+[Patch AI Studio v4.9.64] - Validate global pandas availability and trade_log column handling.
 """
 
 import importlib


### PR DESCRIPTION
## Summary
- bump version references to v4.9.64
- ensure `simulate_trades` creates an empty trade_log DataFrame with `exit_reason` column
- document new patch in CHANGELOG and README
- update test suite header

## Testing
- `pytest -q` *(fails: command not found)*