### PR TITLE
Handle mixed trade_log entries in calculate_metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.65+
+**Version:** v4.9.66+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-05-29
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.65+
+**Version:** 4.9.66+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -205,7 +205,7 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.65+]
+ล่าสุด: [Patch AI Studio v4.9.66+]
 เพิ่ม default dict return ใน `simulate_trades` พร้อมตัวเลือก `return_tuple`
 เพื่อรองรับ backward compatibility และ QA
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@
 - Fixed import flag logic in `import_core_libraries` to correctly reflect successful library imports.
 - Bumped version constant to `4.9.65_FULL_PASS`.
 
+## [v4.9.66+] - 2025-06-02
+- `calculate_metrics` now converts string entries to dictionaries when possible and
+  skips non-dict items.
+- Bumped version constant to `4.9.66_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1,6 +1,6 @@
 """Gold AI Test Suite
 
-[Patch AI Studio v4.9.65] - Validate global pandas availability and import flag handling.
+[Patch AI Studio v4.9.66] - Validate global pandas availability and import flag handling.
 """
 
 import importlib
@@ -1763,6 +1763,21 @@ def test_calculate_metrics_minimal():
     result = ga.calculate_metrics(trade_log_list, fold_tag="minimal_test")
     assert "num_tp" in result
     assert result["num_tp"] == 1
+
+
+def test_calculate_metrics_with_string_entries():
+    ga = safe_import_gold_ai()
+    trade_log_mixed = [
+        '{"exit_reason": "TP", "pnl_usd_net": 15}',
+        {"exit_reason": "SL", "pnl_usd_net": -5},
+        "invalid_entry",
+    ]
+    result = ga.calculate_metrics(trade_log_mixed, fold_tag="mixed")
+    assert result["num_trades"] == 2
+    assert result["num_tp"] == 1
+    assert result["num_sl"] == 1
+    assert result["num_be"] == 0
+    assert result["net_profit"] == 10
 
 
 def test_safe_load_csv_auto_nonexistent(caplog):


### PR DESCRIPTION
## Summary
- tolerate non-dict entries in `calculate_metrics`
- test mixed trade log items
- bump script version to 4.9.66
- update patch notes

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*