### PR TITLE
Add manual TA fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,10 @@
   skips non-dict items.
 - Bumped version constant to `4.9.66_FULL_PASS`.
 
+## [v4.9.67+] - 2025-06-03
+- Added manual fallbacks for RSI, MACD, and ADX when TA functions are missing.
+- Bumped version constant to `4.9.67_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pytest -v --cov=gold_ai2025 --cov-report=term-missing
 📝 Project Notes
 Patch Protocol:
 All logic patches and critical changes must log their version (e.g., [Patch AI Studio v4.9.42+]) in code and test logs per AGENTS.md.
-The latest patch `[Patch AI Studio v4.9.65+]` fixes library import flags to correctly detect installed dependencies.
+The latest patch `[Patch AI Studio v4.9.67+]` adds manual fallbacks for MACD, RSI, and ADX when TA functions are missing.
 
 Type/Format Guards:
 Use only _isinstance_safe and _float_fmt as enforced by QA for all dynamic type or format operations.

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -938,6 +938,38 @@ class TestEdgeCases(unittest.TestCase):
         self.assertIsInstance(result, tuple)
         self.assertEqual(len(result), 12)
 
+    def test_rsi_manual_fallback(self):
+        if not self.pandas_available:
+            self.skipTest("pandas not available")
+        series = self.ga.pd.Series([1, 2, 3, 4, 5, 6], dtype="float32")
+        orig = getattr(getattr(self.ga.ta, "momentum", object()), "RSIIndicator", None)
+        if hasattr(self.ga.ta.momentum, "RSIIndicator"):
+            delattr(self.ga.ta.momentum, "RSIIndicator")
+        try:
+            with self.assertLogs(f"{self.ga.__name__}.rsi", level="WARNING"):
+                result = self.ga.rsi(series, 3)
+            self.assertTrue(result.notna().any())
+        finally:
+            if orig is not None:
+                self.ga.ta.momentum.RSIIndicator = orig
+
+    def test_macd_manual_fallback(self):
+        if not self.pandas_available:
+            self.skipTest("pandas not available")
+        series = self.ga.pd.Series([1, 2, 3, 4, 5, 6], dtype="float32")
+        orig = getattr(getattr(self.ga.ta, "trend", object()), "MACD", None)
+        if hasattr(self.ga.ta.trend, "MACD"):
+            delattr(self.ga.ta.trend, "MACD")
+        try:
+            with self.assertLogs(f"{self.ga.__name__}.macd", level="WARNING"):
+                macd_line, macd_signal, macd_diff = self.ga.macd(series, 5, 3, 2)
+            self.assertTrue(macd_line.notna().any())
+            self.assertTrue(macd_signal.notna().any())
+            self.assertTrue(macd_diff.notna().any())
+        finally:
+            if orig is not None:
+                self.ga.ta.trend.MACD = orig
+
 
 class TestWFVandLotSizing(unittest.TestCase):
     """Additional tests for multi-order simulation, WFV, and lot sizing."""


### PR DESCRIPTION
## Summary
- add manual RSI, MACD, and ADX calculations when ta functions are missing
- bump version to 4.9.67
- document latest patch and update changelog
- test manual fallbacks in edge cases

## Testing
- `pytest -q` *(fails: No module named pytest)*