### PR TITLE
Implement forced entry logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.66+
+**Version:** v4.9.68+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-05-29
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.66+
+**Version:** 4.9.68+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**
@@ -205,9 +205,9 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.66+]
-เพิ่ม default dict return ใน `simulate_trades` พร้อมตัวเลือก `return_tuple`
-เพื่อรองรับ backward compatibility และ QA
+ล่าสุด: [Patch AI Studio v4.9.68+]
+บันทึก forced entry ใน `simulate_trades` ผ่าน `exit_reason='FORCED_ENTRY'`
+และเพิ่มการตรวจสอบใน test suite ว่ามี forced entry ถูก log
 
 ตรวจสอบ audit log & error log ว่า non-numeric (str/NaT/None/nan) ถูก block และ log warning อย่างถูกต้อง
 

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -7222,19 +7222,22 @@ def simulate_trades(
                 pattern_label=str(row.get("Pattern_Label")),
             )
         ):
-            trade_log.append(
-                {
-                    "entry_idx": bar_i,
-                    "entry_time": current_time,
-                    "exit_time": current_time,
-                    "entry_price": pd.to_numeric(row.get("Open"), errors="coerce"),
-                    "exit_price": pd.to_numeric(row.get("Open"), errors="coerce"),
-                    "pnl_usd_net": 0.0,
-                    "exit_reason": "FORCED_ENTRY",
-                }
-            )
-            trade_manager_obj.update_last_trade_time(current_time)
-            continue
+                trade_log.append(
+                    {
+                        "entry_idx": bar_i,
+                        "entry_time": current_time,
+                        "exit_time": current_time,
+                        "entry_price": pd.to_numeric(row.get("Open"), errors="coerce"),
+                        "exit_price": pd.to_numeric(row.get("Open"), errors="coerce"),
+                        "pnl_usd_net": 0.0,
+                        "exit_reason": "FORCED_ENTRY",
+                    }
+                )
+                logger.info(
+                    "[Patch AI Studio v4.9.68+] [FORCED ENTRY] Trade logged with exit_reason=FORCED_ENTRY."
+                )
+                trade_manager_obj.update_last_trade_time(current_time)
+                continue
 
         if open_signal and (not active_orders or getattr(config, "use_reentry", False)):
             open_price = pd.to_numeric(row.get("Open"), errors="coerce")

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1,6 +1,6 @@
 """Gold AI Test Suite
 
-[Patch AI Studio v4.9.66] - Validate global pandas availability and import flag handling.
+[Patch AI Studio v4.9.68] - Validate global pandas availability and import flag handling.
 """
 
 import importlib
@@ -2102,7 +2102,11 @@ def test_risk_trade_manager_forced_entry_spike(monkeypatch):
         log.shape if hasattr(log, "shape") else "N/A",
     )
     assert isinstance(log, pd.DataFrame)
-    assert (log["exit_reason"] == "FORCED_ENTRY").any()
+    assert any(
+        trade.get("exit_reason") == "FORCED_ENTRY" for trade in log.to_dict("records")
+    ), (
+        "Trade log must contain exit_reason='FORCED_ENTRY' if forced entry was triggered"
+    )
     # [Patch AI Studio v4.9.60+] Validate spike guard logic used in forced entry
     row = {"spike_score": 0.6, "Pattern_Label": "Breakout"}
     blocked = spike_guard_blocked(row, "London", config)


### PR DESCRIPTION
## Summary
- log forced entries in `simulate_trades`
- assert forced entry via `exit_reason` check in tests
- bump AGENTS version references to v4.9.68

## Testing
- `pytest -v --cov=gold_ai2025.py --cov=test_gold_ai.py` *(fails: pytest not installed)*