### PR TITLE
Patch v4.9.70 fix ATR variable bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.68+
+**Version:** v4.9.70+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
-**Last updated:** 2025-05-29
+**Last updated:** 2025-06-07
 
 ---
 
@@ -70,7 +70,7 @@
 
 ## 🧩 Agent Test Runner – QA Key Features
 
-**Version:** 4.9.68+
+**Version:** 4.9.70+
 **Purpose:** Validates Gold AI: robust import handling, dynamic mocking, complete unit test execution.
 
 **Capabilities:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@
 - Patch log added to all fallback/guard critical paths.
 - Bumped version constant to `4.9.69_FULL_PASS`.
 
+## [v4.9.70+] - 2025-06-07
+- Fixed `simulate_trades` local variable check that caused `UnboundLocalError` for `atr` when assigning NaN fallback.
+- Bumped version constant to `4.9.70_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -36,7 +36,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.69_FULL_PASS"  # [Patch AI Studio v4.9.69+] RSI/indicator fallback fix
+MINIMAL_SCRIPT_VERSION = "4.9.70_FULL_PASS"  # [Patch AI Studio v4.9.70+] bug fixes for ATR variable
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -7209,14 +7209,15 @@ def simulate_trades(
         current_time = idx
 
         # [Patch AI Studio v4.9.69+] Robust indicator fallback for test robustness
-        if 'atr' not in locals() or atr is None:
-            sim_logger.debug("[Patch AI Studio v4.9.69+] ATR undefined, using NaN fallback.")
+        # [Patch AI Studio v4.9.70+] Use locals().get to avoid UnboundLocalError
+        if locals().get('atr') is None:
+            sim_logger.debug("[Patch AI Studio v4.9.70+] ATR undefined, using NaN fallback.")
             atr = np.nan
-        if 'macd' not in locals() or macd is None:
-            sim_logger.debug("[Patch AI Studio v4.9.69+] MACD undefined, using NaN fallback.")
+        if locals().get('macd') is None:
+            sim_logger.debug("[Patch AI Studio v4.9.70+] MACD undefined, using NaN fallback.")
             macd = np.nan
-        if 'rsi' not in locals() or rsi is None:
-            sim_logger.debug("[Patch AI Studio v4.9.69+] RSI undefined, using default 50.")
+        if locals().get('rsi') is None:
+            sim_logger.debug("[Patch AI Studio v4.9.70+] RSI undefined, using default 50.")
             rsi = 50
         # [Patch AI Studio v4.9.69+] End robust indicator fallback
 


### PR DESCRIPTION
## Summary
- fix `simulate_trades` indicator fallback to avoid UnboundLocalError
- bump version to 4.9.70
- update changelog and agents documentation

## Testing
- `pytest -v --cov=gold_ai2025.py --cov=test_gold_ai.py` *(fails: `pytest: command not found`)*