### PR TITLE
Implement RSI fallback and forced entry audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.72+
+**Version:** v4.9.73+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
-**Last updated:** 2025-06-07
+**Last updated:** 2025-06-09
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,12 @@
 - Forced entry trades always logged with `exit_reason='FORCED_ENTRY'`.
 - Bumped version constant to `4.9.72_FULL_PASS`.
 
+## [v4.9.73+] - 2025-06-09
+- RSI manual fallback now triggers when TA library is missing or series length is insufficient.
+- Forced entry trade log audit records indices of forced trades and logs summary.
+- Added internal test helper `_test_rsi_manual_fallback_coverage`.
+- Bumped version constant to `4.9.73_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.


### PR DESCRIPTION
## Summary
- update version numbers to v4.9.73
- enforce RSI manual fallback whenever the TA library is missing or the series is too short
- audit RSI outputs for NaNs and add test helper `_test_rsi_manual_fallback_coverage`
- track forced entry indices in `simulate_trades` and log an audit summary
- expand tests to cover manual RSI fallback and forced entry audit logic

## Testing
- `pytest -q` *(fails: pytest not installed)*
- `python -m pytest -q` *(fails: No module named pytest)*
- `coverage run -m pytest -q` *(fails: coverage not installed)*