### PR TITLE
Ensure forced entry exit reason handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.78+
+**Version:** v4.9.79+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-06-12
@@ -205,7 +205,7 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.78+]
+ล่าสุด: [Patch AI Studio v4.9.79+]
 บันทึก forced entry ใน `simulate_trades` ผ่าน `exit_reason='FORCED_ENTRY'`
 และเพิ่มการตรวจสอบใน test suite ว่ามี forced entry ถูก log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,14 @@
 - Logged audit summary and indices of modified trades.
 - Bumped version constant to `4.9.78_FULL_PASS`.
 
+## [v4.9.79+] - 2025-06-15
+- Enhanced forced entry detection to scan `Trade_Reason` and `Reason` fields for
+  the substring `FORCED` and set `_forced_entry_flag` accordingly.
+- All forced trades now guarantee `exit_reason='FORCED_ENTRY'` through unified
+  audit logic.
+- Added unit tests for forced BUY, forced SELL, and multi-order scenarios.
+- Bumped version constant to `4.9.79_FULL_PASS`.
+
 
 ## [v4.9.41+] - 2025-05-20
 - Added robust equity_tracker history update with numeric guards.

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -36,7 +36,7 @@ from collections import defaultdict
 from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 # --- Script Version and Basic Setup ---
-MINIMAL_SCRIPT_VERSION = "4.9.78_FULL_PASS"  # [Patch AI Studio v4.9.78+] Forced entry audit patch
+MINIMAL_SCRIPT_VERSION = "4.9.79_FULL_PASS"  # [Patch AI Studio v4.9.79+] Forced entry exit_reason audit
 
 # --- Global Variables for Library Availability ---
 tqdm_imported = False
@@ -7272,7 +7272,9 @@ def simulate_trades(
         open_signal = row.get("Entry_Long", 0) or row.get("Entry_Short", 0)
         side = "BUY" if row.get("Entry_Long", 0) else ("SELL" if row.get("Entry_Short", 0) else None)
         is_forced_entry = False
-        if "Trade_Reason" in row and str(row.get("Trade_Reason", "")).upper().startswith("FORCED"):
+        trade_reason_flag = str(row.get("Trade_Reason", "")).upper()
+        reason_flag = str(row.get("Reason", "")).upper()
+        if "FORCED" in trade_reason_flag or "FORCED" in reason_flag:
             is_forced_entry = True
 
         trade_manager_obj = kwargs.get("trade_manager_obj")

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -2317,6 +2317,85 @@ def test_forced_entry_reason_audit():
     assert trade_log[0].get("exit_reason") == "FORCED_ENTRY"
 
 
+def test_forced_entry_buy_flag_and_reason():
+    pd = safe_import_gold_ai().pd
+    ga = safe_import_gold_ai()
+    df = pd.DataFrame(
+        {
+            "Open": [1000],
+            "High": [1005],
+            "Low": [995],
+            "Close": [1002],
+            "Entry_Long": [1],
+            "ATR_14_Shifted": [1.0],
+            "Signal_Score": [2.0],
+            "Trade_Reason": ["FORCED_BUY"],
+            "session": ["Asia"],
+            "Gain_Z": [0.3],
+            "MACD_hist_smooth": [0.1],
+            "RSI": [50],
+        },
+        index=pd.date_range("2023-01-01", periods=1, freq="min"),
+    )
+    cfg = ga.StrategyConfig({})
+    tl, _, _ = ga.simulate_trades(df.copy(), cfg, return_tuple=True)
+    assert tl[0].get("exit_reason") == "FORCED_ENTRY"
+    assert tl[0].get("_forced_entry_flag")
+
+
+def test_forced_entry_sell_flag_and_reason():
+    pd = safe_import_gold_ai().pd
+    ga = safe_import_gold_ai()
+    df = pd.DataFrame(
+        {
+            "Open": [1000],
+            "High": [1002],
+            "Low": [995],
+            "Close": [998],
+            "Entry_Short": [1],
+            "ATR_14_Shifted": [1.0],
+            "Signal_Score": [2.0],
+            "Trade_Reason": ["FORCED_SELL"],
+            "session": ["Asia"],
+            "Gain_Z": [0.3],
+            "MACD_hist_smooth": [0.1],
+            "RSI": [50],
+        },
+        index=pd.date_range("2023-01-01", periods=1, freq="min"),
+    )
+    cfg = ga.StrategyConfig({})
+    tl, _, _ = ga.simulate_trades(df.copy(), cfg, return_tuple=True)
+    assert tl[0].get("exit_reason") == "FORCED_ENTRY"
+    assert tl[0].get("_forced_entry_flag")
+
+
+def test_forced_entry_multi_order_flags():
+    pd = safe_import_gold_ai().pd
+    ga = safe_import_gold_ai()
+    df = pd.DataFrame(
+        {
+            "Open": [1000, 1005, 1010],
+            "High": [1005, 1010, 1015],
+            "Low": [995, 1000, 1005],
+            "Close": [1002, 1008, 1012],
+            "Entry_Long": [1, 0, 1],
+            "ATR_14_Shifted": [1.0, 1.0, 1.0],
+            "Signal_Score": [2.0, 0.0, 2.0],
+            "Trade_Reason": ["FORCED_BUY", "NORMAL", "FORCED_BUY2"],
+            "session": ["Asia", "Asia", "Asia"],
+            "Gain_Z": [0.3, 0.3, 0.3],
+            "MACD_hist_smooth": [0.1, 0.1, 0.1],
+            "RSI": [50, 50, 50],
+        },
+        index=pd.date_range("2023-01-01", periods=3, freq="min"),
+    )
+    cfg = ga.StrategyConfig({})
+    tl, _, _ = ga.simulate_trades(df.copy(), cfg, return_tuple=True)
+    forced = [t for t in tl if t.get("_forced_entry_flag")]
+    assert len(forced) >= 2
+    assert all(t.get("exit_reason") == "FORCED_ENTRY" for t in forced)
+
+
 # ---------------------------
 # Integration: ML path coverage (mock inference/catboost/shap)
 # ---------------------------


### PR DESCRIPTION
## Summary
- update version references to v4.9.79+
- improve forced entry detection in `simulate_trades`
- extend tests to verify forced BUY/SELL and multi-order flags

## Testing
- `pytest -v --cov` *(fails: ModuleNotFoundError: No module named 'pytest')*
- `python test_gold_ai.py`