### PR TITLE
QA hotfix for headless plotting and forced entry tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 **Version:** v4.9.91+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
-**Last updated:** 2025-06-12
+**Last updated:** 2025-06-13
 
 Gold AI Enterprise QA/Dev version: v4.9.91+ (robust font fallback, ATR NaN fallback, headless plotting)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,4 +287,5 @@
 - Test cases updated for new plot_equity_curve signature and robust StrategyConfig passing
 - Version bump to `4.9.91_FULL_PASS`
 - AGENTS.md references, versioning, and all log/patch tags updated to [Patch AI Studio v4.9.91+]
+- QA hotfix: real numpy.random assigned, headless plotting tests updated, forced entry audit improvements
 


### PR DESCRIPTION
## Summary
- allow partial NaN fallback checks in engineer_m1_features tests
- ensure plotting tests define cfg and use Agg backend
- improve forced entry audit tests
- safe_import_gold_ai now uses real numpy.random when available
- update random dataframe generator comment
- document hotfix in CHANGELOG and update AGENTS date

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*