### PR TITLE
Fix numpy reload warning and bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.104+
+**Version:** v4.9.105+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-06-13
 
-Gold AI Enterprise QA/Dev version: v4.9.104+ (refactor utils and maintain QA coverage)
+Gold AI Enterprise QA/Dev version: v4.9.105+ (refactor utils and maintain QA coverage)
 
 ---
 
@@ -207,7 +207,7 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.104+]
+ล่าสุด: [Patch AI Studio v4.9.105+]
 เพิ่มไฟล์ `pytest.ini` ลงทะเบียน markers `unit` และ `integration`
 ลด PytestUnknownMarkWarning ในรายงานเทส
 ปรับปรุง log และ coverage สม่ำเสมอ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,3 +326,7 @@
 - [Patch][QA v4.9.104] Extract `_safe_numeric` to `refactor_utils` for clarity
 - Version bump to `4.9.104_FULL_PASS`
 
+## [v4.9.105+] - 2025-06-xx
+- [Patch][QA v4.9.105] Ignore NumPy reload warnings via pytest.ini
+- Version bump to `4.9.105_FULL_PASS`
+

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -40,7 +40,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.104_FULL_PASS"  # [Patch][QA v4.9.104] refactor utils
+MINIMAL_SCRIPT_VERSION = "4.9.105_FULL_PASS"  # [Patch][QA v4.9.105] reload warning fix
 
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 markers =
     unit: unit test markers
     integration: integration test markers
+filterwarnings =
+    ignore:The NumPy module was reloaded.*:UserWarning


### PR DESCRIPTION
## Summary
- ignore NumPy reload warnings for cleaner test logs
- bump enterprise version to `v4.9.105`
- update script version constant

## Testing
- `pytest -q`