### PR TITLE
[Patch][QA v4.9.110] เพิ่ม unit test coverage สำหรับ utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.105+
+**Version:** v4.9.110+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-06-13
 
-Gold AI Enterprise QA/Dev version: v4.9.105+ (refactor utils and maintain QA coverage)
+Gold AI Enterprise QA/Dev version: v4.9.110+ (refactor utils and maintain QA coverage)
 
 ---
 
@@ -207,7 +207,7 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.105+]
+ล่าสุด: [Patch AI Studio v4.9.110+]
 เพิ่มไฟล์ `pytest.ini` ลงทะเบียน markers `unit` และ `integration`
 ลด PytestUnknownMarkWarning ในรายงานเทส
 ปรับปรุง log และ coverage สม่ำเสมอ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,3 +330,7 @@
 - [Patch][QA v4.9.105] Ignore NumPy reload warnings via pytest.ini
 - Version bump to `4.9.105_FULL_PASS`
 
+## [v4.9.110+] - 2025-06-xx
+- [Patch][QA v4.9.110] เพิ่ม unit test coverage สำหรับ utility functions
+- Version bump to `4.9.110_FULL_PASS`
+

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -40,7 +40,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.105_FULL_PASS"  # [Patch][QA v4.9.105] reload warning fix
+MINIMAL_SCRIPT_VERSION = "4.9.110_FULL_PASS"  # [Patch][QA v4.9.110] utility coverage tests
 
 
 
@@ -1515,9 +1515,14 @@ def simple_converter(o):
         if np.isnan(o): return None
         if np.isinf(o): return "Infinity" if o > 0 else "-Infinity"
         return float(o)
-    if _isinstance_safe(o, pd.Timestamp): return o.isoformat()
-    if _isinstance_safe(o, np.bool_): return bool(o)
-    if pd.isna(o): return None
+    if _isinstance_safe(o, pd.Timestamp):
+        return o.isoformat()
+    if _isinstance_safe(o, np.bool_):
+        return bool(o)
+    if _isinstance_safe(o, (list, dict)):
+        return o  # [Patch][QA v4.9.110] handle lists/dicts before isna check
+    if pd.isna(o):
+        return None
     if _isinstance_safe(o, (datetime.datetime, datetime.date)): return o.isoformat()
     try:
         if _isinstance_safe(o, (str, bool, list, dict, type(None))):


### PR DESCRIPTION
## Summary
- เพิ่มคลาส `TestUtilityCoverageQA` ครอบคลุมการทดสอบ `safe_float_fmt`, `ensure_dataframe`, `simple_converter`
- ปรับ `simple_converter` ให้รองรับ list/dict ก่อนเรียก `pd.isna`
- bump version เป็น `4.9.110_FULL_PASS`
- อัปเดต AGENTS.md และ CHANGELOG.md ตามเวอร์ชันล่าสุด

## Testing
- `pytest -q`