### PR TITLE
[Patch][QA v4.9.120] เพิ่มชุดทดสอบ coverage simulate_trades และ export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.110+
+**Version:** v4.9.120+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-06-13
 
-Gold AI Enterprise QA/Dev version: v4.9.110+ (refactor utils and maintain QA coverage)
+Gold AI Enterprise QA/Dev version: v4.9.120+ (refactor utils and maintain QA coverage)
 
 ---
 
@@ -207,7 +207,7 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.110+]
+ล่าสุด: [Patch AI Studio v4.9.120+]
 เพิ่มไฟล์ `pytest.ini` ลงทะเบียน markers `unit` และ `integration`
 ลด PytestUnknownMarkWarning ในรายงานเทส
 ปรับปรุง log และ coverage สม่ำเสมอ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,3 +334,7 @@
 - [Patch][QA v4.9.110] เพิ่ม unit test coverage สำหรับ utility functions
 - Version bump to `4.9.110_FULL_PASS`
 
+## [v4.9.120+] - 2025-06-xx
+- [Patch][QA v4.9.120] เพิ่มชุดทดสอบ coverage simulate_trades, export, ML fallback
+- Version bump to `4.9.120_FULL_PASS`
+

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -40,7 +40,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.110_FULL_PASS"  # [Patch][QA v4.9.110] utility coverage tests
+MINIMAL_SCRIPT_VERSION = "4.9.120_FULL_PASS"  # [Patch][QA v4.9.120] coverage booster tests
 
 
 


### PR DESCRIPTION
## Notes
- ปรับเวอร์ชันเอกสารและสคริปต์เป็น `v4.9.120`
- เพิ่มคลาส `TestCoverageBooster` สำหรับกรณี edge ทั้งหลาย
- ทดสอบ export JSON/CSV, simulate_trades, WFV, ML fallback และ risk manager
- แก้ทดสอบให้เข้ากับพฤติกรรมฟังก์ชันจริง

## Testing
- `pytest -q` ผ่านทั้งหมด