### PR TITLE
[Patch][QA v4.9.133] add _safe_numeric tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.132+
+**Version:** v4.9.133+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-06-13
 
-Gold AI Enterprise QA/Dev version: v4.9.132+ (refactor utils and maintain QA coverage)
+Gold AI Enterprise QA/Dev version: v4.9.133+ (refactor utils and maintain QA coverage)
 
 ---
 
@@ -207,12 +207,12 @@ Review vs. this AGENTS.md
 
 No merge without Execution_Test_Unit pass and log review
 
-ล่าสุด: [Patch AI Studio v4.9.132+]
+ล่าสุด: [Patch AI Studio v4.9.133+]
 เพิ่มไฟล์ `pytest.ini` ลงทะเบียน markers `unit` และ `integration`
 ลด PytestUnknownMarkWarning ในรายงานเทส
 ปรับปรุง log และ coverage สม่ำเสมอ
 
-[Patch AI Studio v4.9.132+] Marked _run_backtest_simulation_v34_full as no cover to stabilize coverage during test runs
+[Patch AI Studio v4.9.133+] Marked _run_backtest_simulation_v34_full as no cover to stabilize coverage during test runs
 [Patch AI Studio v4.9.131+] เพิ่มชุดทดสอบ coverage สำหรับ logic simulation/exit/export/ML/WFV/fallback/exception
 
 ตรวจสอบ audit log & error log ว่า non-numeric (str/NaT/None/nan) ถูก block และ log warning อย่างถูกต้อง

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,3 +350,7 @@
 - [Patch][QA v4.9.132] Marked `_run_backtest_simulation_v34_full` as `no cover` for stable tests
 - Version bump to `4.9.132_FULL_PASS`
 
+## [v4.9.133+] - 2025-06-xx
+- [Patch][QA v4.9.133] เพิ่ม unit tests for `_safe_numeric` coverage
+- Version bump to `4.9.133_FULL_PASS`
+

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -40,7 +40,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.132_FULL_PASS"  # [Patch][QA v4.9.132] coverage stabilize
+MINIMAL_SCRIPT_VERSION = "4.9.133_FULL_PASS"  # [Patch][QA v4.9.133] coverage stabilize
 
 
 

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -3472,6 +3472,30 @@ class TestHelperFunctionsSmall(unittest.TestCase):
         self.assertFalse(self.ga.safe_isinstance(mm, bad))
         self.assertFalse(self.ga.safe_isinstance("x", int))
 
+    def test_safe_numeric_none(self):
+        self.assertEqual(self.ga._safe_numeric(None, default=0.0), 0.0)
+
+    def test_safe_numeric_string_number(self):
+        self.assertEqual(self.ga._safe_numeric("5"), 5.0)
+
+    def test_safe_numeric_string_invalid(self):
+        self.assertEqual(self.ga._safe_numeric("abc", default=2.0), 2.0)
+
+    def test_safe_numeric_pd_na(self):
+        pd = self.ga.pd
+        self.assertEqual(self.ga._safe_numeric(pd.NA, default=1.0, nan_as=-1), -1)
+
+    def test_safe_numeric_exception(self):
+        pd = self.ga.pd
+        orig = pd.to_numeric
+        def boom(*args, **kwargs):
+            raise ValueError("boom")
+        pd.to_numeric = boom
+        try:
+            self.assertEqual(self.ga._safe_numeric("x", default=1.0, log_ctx="t"), 1.0)
+        finally:
+            pd.to_numeric = orig
+
 
 class TestCoverageADA(unittest.TestCase):
     """Artificially exercise lines for coverage using exec."""


### PR DESCRIPTION
## Summary
- bump version references to v4.9.133+
- update changelog for v4.9.133 entry
- set `MINIMAL_SCRIPT_VERSION` to `4.9.133_FULL_PASS`
- add unit tests for `_safe_numeric`

## Testing
- `pytest -v --cov`