### PR TITLE
Fix spike_score fallback and categorical fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.141+
+**Version:** v4.9.142+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
-**Last updated:** 2025-06-15
+**Last updated:** 2025-06-30
 
 Gold AI Enterprise QA/Dev version: v4.9.139+ (refactor utils and maintain QA coverage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,3 +387,7 @@
 - [Patch][QA v4.9.141] แก้ปัญหา AttributeError จากการอ้างอิง `datetime.datetime` โดยกำหนด alias `dt`
 - Version bump to `4.9.141_FULL_PASS`
 
+## [v4.9.142+] - 2025-06-xx
+- [Patch][QA v4.9.142] แก้ spike_score ใช้ Series fallback และเพิ่มการจัดการหมวดหมู่ Unknown ใน clean_m1_data
+- Version bump to `4.9.142_FULL_PASS`
+


### PR DESCRIPTION
## Summary
- fix spike_score creation when Gain_Z or other columns missing
- handle categorical NaN fill by adding Unknown category
- bump version to 4.9.142 and update CHANGELOG

## Testing
- `pytest -q`