### PR TITLE
[Patch][QA v4.9.151] strict enterprise data checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.146+
+**Version:** v4.9.151+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
-**Last updated:** 2025-06-30
+**Last updated:** 2025-07-01
 
 Gold AI Enterprise QA/Dev version: v4.9.139+ (refactor utils and maintain QA coverage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,3 +407,8 @@
 - [Patch][QA v4.9.146] Multi-logic QA updates: ATR fallback warning, font setup flag, improved Colab drive detection, config path fallback
 - Version bump to `4.9.146_FULL_PASS`
 
+## [v4.9.151+] - 2025-07-01
+- [Patch][QA v4.9.151] Strict enterprise mode for data loading and feature engineering.
+- Updated safe_load_csv_auto, engineer_m1_features, and rsi to raise errors on any invalid input or empty data.
+- Version bump to `4.9.151_FULL_PASS`
+


### PR DESCRIPTION
## Summary
- bump version refs to v4.9.151
- enforce strict errors in `safe_load_csv_auto`, `engineer_m1_features`, and `rsi`
- adjust tests to expect raised errors and stub features for integration tests

## Testing
- `pytest -q`