### PR TITLE
Add lag_features_setting arg

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.151+
+**Version:** v4.9.152+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
-**Last updated:** 2025-07-01
+**Last updated:** 2025-07-xx
 
 Gold AI Enterprise QA/Dev version: v4.9.139+ (refactor utils and maintain QA coverage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,3 +412,8 @@
 - Updated safe_load_csv_auto, engineer_m1_features, and rsi to raise errors on any invalid input or empty data.
 - Version bump to `4.9.151_FULL_PASS`
 
+## [v4.9.152+] - 2025-07-xx
+- [Patch][QA v4.9.151] engineer_m1_features now accepts optional `lag_features_setting` for compatibility with production/main.
+- Added logging of all arguments and ignore message when lag_features_setting is provided.
+- Version bump to `4.9.152_FULL_PASS`
+

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -40,7 +40,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.151_FULL_PASS"  # [Patch][QA v4.9.151] strict enterprise behavior
+MINIMAL_SCRIPT_VERSION = "4.9.152_FULL_PASS"  # [Patch][QA v4.9.152] strict enterprise behavior
 
 
 
@@ -2434,15 +2434,30 @@ def get_session_tag(timestamp: pd.Timestamp, session_times_utc_config: dict) -> 
         session_logger.error(f"   (Error) Error in get_session_tag for {timestamp}: {e}", exc_info=True)
         return "Error_Tagging"
 
-def engineer_m1_features(df: pd.DataFrame, config: Optional["StrategyConfig"] = None) -> pd.DataFrame:
+def engineer_m1_features(
+    df: pd.DataFrame,
+    config: Optional["StrategyConfig"] = None,
+    lag_features_setting=None,
+) -> pd.DataFrame:
     """
     [Patch][QA v4.9.151][Enterprise] Feature engineering (no patch/fallback allowed).
-    If any required column missing or NaN, raise error immediately.
+    รองรับการเรียกแบบ 2 หรือ 3 argument โดย lag_features_setting จะไม่ถูกใช้ใน logic หลัก
+    แต่จำเป็นต้องรับไว้เพื่อความเข้ากันได้กับ production/main
     """
     import ta
     import pandas as pd
     import numpy as np
     logger = logging.getLogger(f"{__name__}.engineer_m1_features")
+    logger.info(
+        "[Patch][QA v4.9.151] engineer_m1_features invoked: df.shape=%r, config=%r, lag_features_setting=%r",
+        df.shape,
+        config,
+        lag_features_setting,
+    )
+    if lag_features_setting is not None:
+        logger.info(
+            "[Patch][QA v4.9.151] lag_features_setting received, but not used in core logic (SAFE IGNORE)"
+        )
     price_cols = ["Open", "High", "Low", "Close"]
     missing_cols = [c for c in price_cols if c not in df.columns]
     if missing_cols:

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -1889,6 +1889,17 @@ class TestFeatureEngineeringCoverage:
         with pytest.raises(ValueError):
             self.ga.engineer_m1_features(df, self.config)
 
+    def test_engineer_m1_features_three_args(self):
+        df = self.ga.pd.DataFrame({
+            "Open": [1, 2],
+            "High": [2, 3],
+            "Low": [0, 1],
+            "Close": [1, 2],
+        })
+        config = self.ga.StrategyConfig({})
+        with pytest.raises(ValueError):
+            self.ga.engineer_m1_features(df.copy(), config, {})
+
     def test_clean_m1_data_empty(self):
         df = self.ga.pd.DataFrame()
         clean, feats = self.ga.clean_m1_data(df, self.config)


### PR DESCRIPTION
## Notes
- อัพเดต `engineer_m1_features` ให้รับ argument `lag_features_setting` พร้อมบันทึก log และรองรับการเรียกแบบ 3 argument
- เพิ่ม test `test_engineer_m1_features_three_args`
- ปรับเวอร์ชันเป็น `v4.9.152` และบันทึก CHANGELOG

## Summary
- เพิ่ม log และ argument ใน `engineer_m1_features`
- เพิ่มรุ่น `4.9.152_FULL_PASS`
- อัพเดต AGENTS.md และ CHANGELOG.md
- ทดสอบ `pytest` ผ่านทั้งหมด 281 รายการ