### PR TITLE
Apply QA v4.9.153 patches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.152+
+**Version:** v4.9.153+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-07-xx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,3 +417,9 @@
 - Added logging of all arguments and ignore message when lag_features_setting is provided.
 - Version bump to `4.9.152_FULL_PASS`
 
+## [v4.9.153+] - 2025-07-xx
+- [Patch][QA v4.9.152] Removed Thai font auto-install logic and defaulted to English fonts only.
+- [Patch][QA v4.9.152] Strict config path fallback with error if no config found.
+- [Patch][QA v4.9.152] engineer_m1_features validates required columns individually.
+- Version bump to `4.9.153_FULL_PASS`
+

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -360,6 +360,16 @@ class TestGoldAI2025(unittest.TestCase):
         self.assertEqual(cfg.risk_per_trade, 0.02)
         self.assertEqual(cfg.max_lot, 2.0)
 
+    def test_load_config_path_fallback(self):
+        ga = self.gold_ai
+        with patch("os.path.exists", return_value=True):
+            self.assertEqual(ga.load_config("config.yaml"), "config.yaml")
+        with patch("os.path.exists", side_effect=lambda p: p == "/content/drive/MyDrive/new/config.yaml"):
+            self.assertEqual(ga.load_config("missing.yaml"), "/content/drive/MyDrive/new/config.yaml")
+        with patch("os.path.exists", return_value=False):
+            with self.assertRaises(FileNotFoundError):
+                ga.load_config("missing.yaml")
+
     def test_setup_output_directory(self):
         # [Patch][QA v4.9.87] Use fixed path /content/drive/MyDrive/new only
         base_dir = "/content/drive/MyDrive/new"


### PR DESCRIPTION
## Summary
- enforce DejaVu Sans font by default
- add strict config path lookup
- validate required columns individually in engineer_m1_features
- update main font setup call
- bump version to v4.9.153 and document changes
- test load_config path fallback

## Testing
- `pytest -q`