### PR TITLE
Fix Trend Zone merge column filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.153+
+**Version:** v4.9.154+
 **Project:** Gold AI (Enterprise Refactor)
 **Maintainer:** AI Studio QA/Dev Team
 **Last updated:** 2025-07-xx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,3 +423,6 @@
 - [Patch][QA v4.9.152] engineer_m1_features validates required columns individually.
 - Version bump to `4.9.153_FULL_PASS`
 
+## [v4.9.154+] - 2025-07-xx
+- [Patch][QA v4.9.154] main merges M15 Trend Zone using only the 'Trend_Zone' column to avoid duplicate OHLC columns.
+- Version bump to `4.9.154_FULL_PASS`

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -43,7 +43,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.153_FULL_PASS"  # [Patch][QA v4.9.153] strict enterprise behavior
+MINIMAL_SCRIPT_VERSION = "4.9.154_FULL_PASS"  # [Patch][QA v4.9.154] strict enterprise behavior
 
 
 
@@ -6578,6 +6578,7 @@ def main(run_mode: str = 'FULL_PIPELINE', config_file: str = "config.yaml", suff
                 df_m1_with_trend = df_m1_prepared.copy()
                 df_m1_with_trend['Trend_Zone'] = "NEUTRAL"
             else:
+                df_m15_trend_zone = df_m15_trend_zone[["Trend_Zone"]]
                 df_m1_with_trend = pd.merge_asof(
                     df_m1_prepared.sort_index(),
                     df_m15_trend_zone.sort_index(),


### PR DESCRIPTION
## Summary
- trim Trend Zone dataframe before merging with M1 data
- bump enterprise version to v4.9.154+
- document change in CHANGELOG

## Testing
- `pytest -v --cov`