### PR TITLE
ปรับปรุง engineer_m1_features ให้คำนวน ATR ชัดเจน

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
-**Version:** v4.9.159+  
+**Version:** v4.9.161+
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  
 **Last updated:** 2025-07-xx
 
-Gold AI Enterprise QA/Dev version: v4.9.159+ (major patch for NaN/feature audit, config fail-safe, patch verbose suppression, class attribute fix)
+Gold AI Enterprise QA/Dev version: v4.9.161+ (ATR feature update, doc update instructions, config fail-safe, patch verbose suppression, class attribute fix)
 
 ---
 
@@ -76,6 +76,7 @@ Gold AI Enterprise QA/Dev version: v4.9.159+ (major patch for NaN/feature audit,
 - **Patch Logging:**  
   All logic changes must log `[Patch AI Studio vX.Y.Z+]` หรือ `[Patch][QA vX.Y.Z+]` ตรงกับเวอร์ชันจริงใน CHANGELOG.md
   Any core logic change: notify relevant owners (GPT Dev, OMS_Guardian, ML_Innovator).
+  After each patch/update, append details to **CHANGELOG.md** และปรับเวอร์ชันใน **AGENTS.md** ให้ตรงกัน
 
 - **Critical Constraints:**  
     - **No direct production commits:** Must pass QA (`pytest -v`, `--cov`)
@@ -86,7 +87,7 @@ Gold AI Enterprise QA/Dev version: v4.9.159+ (major patch for NaN/feature audit,
 
 ## 🚦 **Enterprise QA Status (Current): ON**
 
-- QA Enterprise Status: **ON (patch v4.9.159+)**
+- QA Enterprise Status: **ON (patch v4.9.161+)**
 - Patch focus: **Fail-safe NaN/inf cleaning in all critical features, class attribute compliance, config path & logging suppression, drift audit.**
 - **กำลังรอการตรวจสอบ/approve จาก OMS_Guardian, Model_Inspector, Execution_Test_Unit หลัง patch ใหม่**
 - Release readiness: **Only after**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,3 +457,8 @@
 ## [v4.9.160+] - 2025-07-xx
 - [Patch][QA v4.9.160] Added default `use_meta_classifier` to StrategyConfig to prevent AttributeError.
 - Version bump to `4.9.160_FULL_PASS`
+
+## [v4.9.161+] - 2025-07-xx
+- [Patch][QA v4.9.161] Renamed `ATR_Shifted` to `ATR_14_Shifted` and introduced `ATR_14_Rolling_Avg`.
+- [Patch][QA v4.9.161] Added guideline to update CHANGELOG.md and AGENTS.md after each patch.
+- Version bump to `4.9.161_FULL_PASS`

--- a/gold_ai2025.py
+++ b/gold_ai2025.py
@@ -43,7 +43,7 @@ from typing import Union, Optional, Callable, Any, Dict, List, Tuple, NamedTuple
 
 
 
-MINIMAL_SCRIPT_VERSION = "4.9.160_FULL_PASS"  # [Patch][QA v4.9.160] add use_meta_classifier default
+MINIMAL_SCRIPT_VERSION = "4.9.161_FULL_PASS"  # [Patch][QA v4.9.161] ATR rolling avg & doc updates
 
 
 
@@ -2467,6 +2467,7 @@ def engineer_m1_features(
     import pandas as pd
     import numpy as np
     logger = logging.getLogger(f"{__name__}.engineer_m1_features")
+    eng_m1_logger = logger
     logger.info(
         "[Patch][QA v4.9.154+] engineer_m1_features invoked: df.shape=%r, config=%r, lag_features_setting=%r",
         df.shape,
@@ -2487,6 +2488,13 @@ def engineer_m1_features(
     df["ATR_14"] = ta.volatility.AverageTrueRange(
         high=df["High"], low=df["Low"], close=df["Close"], window=14, fillna=False
     ).average_true_range()
+    df["ATR_14_Shifted"] = df["ATR_14"].shift(1).bfill().astype("float32")
+    atr_avg_window = getattr(config, "atr_rolling_avg_period", 50) if config else 50
+    df["ATR_14_Rolling_Avg"] = (
+        df["ATR_14"].rolling(window=atr_avg_window, min_periods=max(1, atr_avg_window // 2))
+        .mean()
+        .astype("float32")
+    )
     if df["ATR_14"].isna().any():
         logger.critical("[Patch][QA v4.9.151][Enterprise] ATR_14 has NaN after calculation. Raising error.")
         raise ValueError("ATR_14 has NaN after calculation.")
@@ -2499,7 +2507,7 @@ def engineer_m1_features(
             "[Patch][QA v4.9.156][Enterprise] Gain_Z all NaN after calculation. Insufficient data."
         )
         raise ValueError("Gain_Z all NaN after calculation.")
-    critical_cols = [c for c in ["Gain_Z", "ATR_14", "ATR_Shifted"] if c in df.columns]
+    critical_cols = [c for c in ["Gain_Z", "ATR_14", "ATR_14_Shifted"] if c in df.columns]
     nan_rows = df[critical_cols].isnull().any(axis=1).sum() if critical_cols else 0
     if nan_rows > 0:
         logger.warning(
@@ -2511,7 +2519,6 @@ def engineer_m1_features(
         logger.info(
             f"[Patch][QA v4.9.158+] {col} NaN remaining after clean: {n_nan}"
         )
-    return df
 
     # ADX
     if all(c in df.columns for c in ['High', 'Low', 'Close']):
@@ -2642,7 +2649,7 @@ def engineer_m1_features(
         df['model_tag'] = 'N/A'
 
     eng_m1_logger.info("(Success) สร้าง Features M1 (using StrategyConfig) เสร็จสิ้น.")
-    return df.reindex(df_m1.index) # Reindex to original to ensure no rows are lost/gained if NaNs were dropped internally
+    return df
 
 def clean_m1_data(df_m1: pd.DataFrame, config: 'StrategyConfig') -> tuple[pd.DataFrame, list]:  # type: ignore
     """Cleans M1 data, converts types, and identifies features for drift analysis, using config."""
@@ -5086,7 +5093,7 @@ def _run_backtest_simulation_v34_full(
                     trade_manager_obj.update_last_trade_time(now_bar)
                     atr_at_entry_val_open_call = pd.to_numeric(row_data_bar.get("ATR_14_Shifted"), errors='coerce')
                     if pd.isna(atr_at_entry_val_open_call) or atr_at_entry_val_open_call < 1e-9: # pragma: no cover
-                        sim_logger.warning(f"   Cannot open order at {now_bar}: Invalid ATR_Shifted ({atr_at_entry_val_open_call}).")
+                        sim_logger.warning(f"   Cannot open order at {now_bar}: Invalid ATR_14_Shifted ({atr_at_entry_val_open_call}).")
                     else:
                         entry_price_new_val_call = pd.to_numeric(row_data_bar.get("Open"), errors='coerce')
                         if pd.isna(entry_price_new_val_call): sim_logger.error(f"  Cannot open order at {now_bar}: Invalid Open price."); continue # pragma: no cover


### PR DESCRIPTION
## Summary
- แก้การสร้างคอลัมน์ ATR ให้ครบถ้วน (`ATR_14_Shifted`, `ATR_14_Rolling_Avg`)
- ปรับชื่อคอลัมน์ใน `critical_cols`
- ลบ `return` ก่อนเวลาและคืนค่าข้อมูลหลังปรับปรุง
- กำหนดตัวแปร `eng_m1_logger`
