### PR TITLE
[Patch][QA v4.9.164] improve risk logs and raw data cleaning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
 
-**Version:** v4.9.163+
+**Version:** v4.9.164+
 =======
-**Version:** v4.9.162+
+**Version:** v4.9.163+
 
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,4 +471,9 @@
 ## [v4.9.163+] - 2025-07-xx
 - [Patch][QA v4.9.163] Added unit test to verify equity history tracking uses a dictionary.
 - Version bump to `4.9.163_FULL_PASS`
+
+## [v4.9.164+] - 2025-07-xx
+- [Patch][QA v4.9.164] Raw CSV loading drops duplicates and invalid OHLC rows.
+- [Patch][QA v4.9.164] RiskManager logs drawdown updates and kill switch events.
+- Version bump to `4.9.164_FULL_PASS`
 =======


### PR DESCRIPTION
## Summary
- clean raw CSVs in `safe_load_csv_auto` (drop duplicates and invalid OHLC rows)
- enhance RiskManager logging when updating drawdowns
- bump script version to `4.9.164_FULL_PASS`
- document changes in AGENTS.md and CHANGELOG

## Testing
- `pytest -q`