### PR TITLE
Add fold QA summary export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 **Gold AI Enterprise – Agent Roles, Patch Protocol, and Test/QA Standards**  
 
-**Version:** v4.9.166+
+**Version:** v4.9.201+
 =======
-**Version:** v4.9.165+
+**Version:** v4.9.201+
 
 **Project:** Gold AI (Enterprise Refactor)  
 **Maintainer:** AI Studio QA/Dev Team  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,3 +486,8 @@
 - [Patch][QA v4.9.166] Added missing libraries to requirements and synced version constants.
 - Version bump to `4.9.166_FULL_PASS`
 
+## [v4.9.201+] - 2025-07-xx
+- [Patch][QA v4.9.201] Auto QA root cause summary export for each fold.
+- Added `export_fold_qa_summary` and integrated calls in walk-forward pipeline.
+- Version bump to `4.9.201_FULL_PASS`
+

--- a/test_gold_ai.py
+++ b/test_gold_ai.py
@@ -3285,6 +3285,13 @@ class TestCoverageBooster(unittest.TestCase):
         result_fail = ga.export_trade_log_to_csv(log, "denied", "/no_such_dir", self.cfg)
         self.assertIsNone(result_fail)
 
+    def test_export_fold_qa_summary(self):
+        ga = self.ga
+        tmp_dir = "/tmp/gold_ai_test_export"
+        os.makedirs(tmp_dir, exist_ok=True)
+        result = ga.export_fold_qa_summary(1, "no_data", {"rows_after_clean": 0}, tmp_dir)
+        self.assertTrue(result and os.path.exists(result))
+
     def test_run_all_folds_with_threshold_empty_fold(self):
         pd = self.pd
         ga = self.ga


### PR DESCRIPTION
## Summary
- introduce `export_fold_qa_summary` helper for root cause logging
- integrate QA summary export into walk-forward loop
- bump version to 4.9.201
- document new version in AGENTS and CHANGELOG
- test export_fold_qa_summary in unit tests

## Testing
- `pytest -q`